### PR TITLE
Use box-shadow instead of border

### DIFF
--- a/kofta/src/vscode-webview/components/Avatar.tsx
+++ b/kofta/src/vscode-webview/components/Avatar.tsx
@@ -20,8 +20,8 @@ export const Avatar: React.FC<AvatarProps> = ({
         width: size,
         height: size,
         borderRadius: circle ? "50%" : "30%",
-        border: active
-          ? "3px solid var(--vscode-textLink-foreground)"
+        boxShadow: active
+          ? "0 0 0 3px var(--vscode-textLink-foreground)"
           : undefined,
       }}
       src={src}


### PR DESCRIPTION
Using `box-shadow` doesn't take space