### PR TITLE
let user to move to listener from speaker

### DIFF
--- a/kofta/src/vscode-webview/pages/RoomPage.tsx
+++ b/kofta/src/vscode-webview/pages/RoomPage.tsx
@@ -153,6 +153,19 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
               Requesting to speak ({unansweredHands.length})
             </div>
           ) : null}
+          {iCanSpeak && me && !(me.id in room.raiseHandMap) ? (
+            <CircleButton
+              size={70}
+              onClick={() => {
+                const y = window.confirm("Are you sure you want to remove as a speaker?");
+                if (y) {
+                  wsend({ op: "set_listener", d:{ userId: me.id } });
+                }
+              }}
+            >
+              <Codicon width={36} height={36} name="close" />
+            </CircleButton>
+          ) : null}
           {unansweredHands.map((u) => (
             <RoomUserNode
               key={u.id}


### PR DESCRIPTION
Not tested yet.
Just reuse the moderator **set_listener** logic.
( Hope the current user have the permission to move himself/herself to listener. )

Issue #10 