### PR TITLE
releases.exs: It's SENTRY_DSN, not SENTRY_DNS

### DIFF
--- a/kousa/config/releases.exs
+++ b/kousa/config/releases.exs
@@ -20,8 +20,10 @@ config :kousa,
       raise("""
       environment variable RABBITMQ_URL is missing.
       """),
-  web_url: "https://dogehouse.tv",
-  api_url: "https://api.dogehouse.tv",
+  web_url: 
+    System.get_env("WEB_URL") || "https://dogehouse.tv",
+  api_url: 
+    System.get_env("API_URL") || "https://api.dogehouse.tv",
   access_token_secret:
     System.get_env("ACCESS_TOKEN_SECRET") ||
       raise("""
@@ -49,9 +51,9 @@ config :kousa,
 
 config :sentry,
   dsn:
-    System.get_env("SENTRY_DNS") ||
+    System.get_env("SENTRY_DSN") ||
       raise("""
-      environment variable SENTRY_DNS is missing.
+      environment variable SENTRY_DSN is missing.
       """),
   environment_name: :prod,
   enable_source_code_context: true,

--- a/kousa/config/releases.exs
+++ b/kousa/config/releases.exs
@@ -49,9 +49,13 @@ config :kousa,
       Create an oauth application on GitHub to get one
       """)
 
+if(System.get_env("SENTRY_DNS") != nil) do
+    IO.warn("The SENTRY_DNS environment variable is deprecated, use SENTRY_DSN instead")
+end
+
 config :sentry,
   dsn:
-    System.get_env("SENTRY_DSN") ||
+    System.get_env("SENTRY_DSN") || System.get_env("SENTRY_DNS") ||
       raise("""
       environment variable SENTRY_DSN is missing.
       """),


### PR DESCRIPTION
Also, I added an way for self-hosted instances to have their own environment variable for both Web UI and API server hosts. If left blank, it'll fall back to the defaults as https://dogehouse.tv and https://api.dogehouse.tv