### PR TITLE
feat: toggle room visibility

### DIFF
--- a/kofta/src/vscode-webview/Routes.tsx
+++ b/kofta/src/vscode-webview/Routes.tsx
@@ -50,7 +50,11 @@ export const Routes: React.FC<RoutesProps> = () => {
         setCurrentRoom((cr) =>
           !cr || cr.id !== roomId ? cr : { ...cr, name, isPrivate }
         );
-        toast("room is now public", { type: "info" });
+        if (isPrivate) {
+          toast("room is now public", { type: "info" });
+        } else {
+          toast("room is now private", { type: "info" });
+        }
       },
       banned: () => {
         toast("you got banned", { type: "error" });

--- a/kofta/src/vscode-webview/Routes.tsx
+++ b/kofta/src/vscode-webview/Routes.tsx
@@ -50,11 +50,7 @@ export const Routes: React.FC<RoutesProps> = () => {
         setCurrentRoom((cr) =>
           !cr || cr.id !== roomId ? cr : { ...cr, name, isPrivate }
         );
-        if (isPrivate) {
-          toast("room is now public", { type: "info" });
-        } else {
-          toast("room is now private", { type: "info" });
-        }
+        toast(`Room is now ${isPrivate ? "private" : "public"}`, { type: "info" });
       },
       banned: () => {
         toast("you got banned", { type: "error" });

--- a/kofta/src/vscode-webview/components/BottomVoiceControl.tsx
+++ b/kofta/src/vscode-webview/components/BottomVoiceControl.tsx
@@ -9,6 +9,7 @@ import { Codicon } from "../svgs/Codicon";
 import { PhoneMissed, UserPlus, Mic, MicOff, X, Settings } from "react-feather";
 import { Footer } from "./Footer";
 import { renameRoomAndMakePublic } from "../../webrtc/utils/renameRoomAndMakePublic";
+import { renameRoomAndMakePrivate } from "../../webrtc/utils/renameRoomAndMakePrivate";
 import { Modal } from "./Modal";
 import { Button } from "./Button";
 
@@ -166,7 +167,16 @@ export const BottomVoiceControl: React.FC<BottomVoiceControlProps> = ({
               >
                 make room public
               </Button>
-            ) : null}
+            ) : (
+              <Button
+                onClick={() => {
+                  renameRoomAndMakePrivate(currentRoom.name);
+                  setSettingsOpen(false);
+                }}
+              >
+                make room private
+              </Button>
+            )}
           </>
         ) : null}
       </Modal>

--- a/kofta/src/webrtc/utils/renameRoomAndMakePrivate.ts
+++ b/kofta/src/webrtc/utils/renameRoomAndMakePrivate.ts
@@ -1,0 +1,8 @@
+import { wsend } from "../../createWebsocket";
+
+export const renameRoomAndMakePrivate = (currentName: string) => {
+  const roomName = window.prompt("Set private room name", currentName);
+  if (roomName) {
+    wsend({ op: "make_room_private", d: { newName: roomName } });
+  }
+};

--- a/kousa/lib/business-logic/room_logic.ex
+++ b/kousa/lib/business-logic/room_logic.ex
@@ -26,6 +26,22 @@ defmodule Kousa.BL.Room do
     end
   end
 
+    @spec make_room_private(any, any) :: nil | :ok
+  def make_room_private(user_id, new_name) do
+    # this needs to be refactored if a user can have multiple rooms
+    case Kousa.Data.Room.set_room_privacy_by_creator_id(user_id, true, new_name) do
+      {1, [room]} ->
+        Kousa.Gen.RoomSession.send_cast(
+          room.id,
+          {:send_ws_msg, :vscode,
+           %{op: "room_privacy_change", d: %{roomId: room.id, name: room.name, isPrivate: true}}}
+        )
+
+      _ ->
+        nil
+    end
+  end
+
   def invite_to_room(user_id, user_id_to_invite) do
     user = Kousa.Data.User.get_by_id(user_id)
 


### PR DESCRIPTION
Quick way to allow room privacy toggling which fixes #67 . Underlying code to switch between public & private can be cleaned up but I can only get to it later. If you need this out now, it has a first iteration.