### PR TITLE
chore(Login): remove extra space in the open source list item

### DIFF
--- a/kofta/src/vscode-webview/pages/Login.tsx
+++ b/kofta/src/vscode-webview/pages/Login.tsx
@@ -30,8 +30,7 @@ export const Login: React.FC<LoginProps> = () => {
           <li>- Dark theme</li>
           <li>- Open sign ups</li>
           <li>- Cross platform support</li>
-          <li>
-            -{" "}
+          <li>- 
             <a
               style={{ color: "var(--vscode-textLink-foreground)" }}
               href="https://github.com/benawad/dogehouse"


### PR DESCRIPTION
This PR is not a big deal but I saw that the **Login** page had an extra space in the **Open Source** list item and that made me uncomfortable 😂 