### PR TITLE
Prevent other icons from moving on mute state change

### DIFF
--- a/kofta/src/vscode-webview/components/BottomVoiceControl.tsx
+++ b/kofta/src/vscode-webview/components/BottomVoiceControl.tsx
@@ -27,7 +27,7 @@ interface BottomVoiceControlProps {}
 
 const iconSize = 24;
 const iconColor = "#8C8C8C";
-const buttonStyle = { padding: "10px", color: "#8C8C8C", fontSize: 14 };
+const buttonStyle = { padding: "10px", color: "#8C8C8C", fontSize: 14, flex: 1 };
 
 export const BottomVoiceControl: React.FC<BottomVoiceControlProps> = ({
   children,


### PR DESCRIPTION
Fixes #165 

Change this:

![Hnet com-image](https://user-images.githubusercontent.com/38838675/107880911-91678e00-6f03-11eb-8178-01eac5102010.gif)

To this:

![DWFV8a14z9](https://user-images.githubusercontent.com/38838675/107880955-c07dff80-6f03-11eb-948e-4214668d866a.gif)
