### PR TITLE
Update README: Extend local installation instructions and improve project file structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@
 https://dogehouse.tv/
 
 ## Structure
-
-- kousa -> Elixir API
-- shawarma -> Voice Server
-- kofta -> React frontend
-- dinner -> Puppeteer shenanigans
+```
+📦 dogehouse
+┣ 📂 dinner
+┃ ┗ ⚙️ Puppeteer shenanigans
+┣ 📂 kofta
+┃ ┗ ⚙️ React Frontend
+┣ 📂 kousa
+┃ ┗ ⚙️ Elixir API
+┗ 📂 shawarma
+  ┗ ⚙️ Voice Server
+```
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ WEBRTC_LISTEN_IP=127.0.0.1
 
 Then run `npm run build` and `npm start`.
 
+### Frontend
+
 #### `kofta`
 Navigate to `/kofta` and create an `.env` file based on `.env.example`.
 

--- a/README.md
+++ b/README.md
@@ -24,26 +24,91 @@ DogeHouse is open to contributions, but I recommend creating an issue or replyin
 
 ## How to run locally
 
-### backend
+### Backend
 
-0. Install and start RabbitMQ
-1. Install and start Postgresql
-2. Create a DB inside Postgresql called `kousa_repo2`
-3. Install Elixir
-4. Inside `kousa` 
-- run `mix deps.get`
-- run `mix ecto.migrate`
-- run `iex -S mix` (This starts the server, read all the error messages and add those environment variables)
-5. Inside `shawarma`
-- run `npm i`
-- set an env variable `WEBRTC_LISTEN_IP` to `127.0.0.1`
-- run `npm run build`
-- run `npm start`
-6. Inside `kofta`
-- run `npm i`
-- run `npm start`
+#### RabbitMQ
+Install RabbitMQ:
+- **macOS**: Run `brew install rabbitmq`
+- **Windows**: Run `choco install rabbitmq`
+- **Linux**: Follow their installation guide [here](https://www.rabbitmq.com/download.html).
 
-(Austin lost power so I'm doing this from my phone, will make a better version soon)
+Start RabbitMQ
+- **macOS**: Run `brew services start rabbitmq`
+- **Windows**: Setup guide [here](https://www.rabbitmq.com/install-windows.html).
+- **Linux**: Setup guide [here](https://www.rabbitmq.com/install-debian.html).
+
+#### PostgreSQL
+Install PostgreSQL:
+- **macOS**: Run `brew install postgresql`
+- **Windows**: Follow [this](https://www.postgresqltutorial.com/install-postgresql/) guide.
+- **Linux**: Follow [this](https://www.postgresqltutorial.com/install-postgresql-linux/) guide.
+
+Start PostgreSQL:
+- **macOS**: Run `brew services start postgresql`
+- **Windows**: Start PostgreSQL through the control panel or run `net start postgresql-{version}` 
+- **Linux**: Run `/etc/rc.d/init.d/postgresql start`
+
+Create a DB named `kousa_repo2`:
+
+```shell
+$ psql postgres
+
+$ CREATE DATABASE kousa_repo2;
+```
+
+#### Elixir
+Elixir installation guide [here](https://elixir-lang.org/install.html).
+
+
+#### `kousa`
+Navigate to `/kousa` and set the following environment variables:
+```
+export DATABASE_URL=postgres://user:password@localhost/kousa_repo2
+export BEN_GITHUB_ID=7872329
+export RABBITMQ_URL=amqp://user:password@yourinternalip:5672
+export ACCESS_TOKEN_SECRET=
+export REFRESH_TOKEN_SECRET=
+export GITHUB_CLIENT_ID=
+export TWITTER_API_KEY=
+export TWITTER_SECRET_KEY=
+export TWITTER_BEARER_TOKEN=
+export GITHUB_CLIENT_SECRET=
+export SENTRY_DNS=
+export API_URL=http://localhost:4001
+export WEB_URL=http://localhost:3000
+export PORT=4001
+```
+
+> You can save this variables in a `.txt` and run `source path/to/file.txt`
+
+Run the following commands:
+```shell
+$ mix deps.get
+$ mix ecto.migrate
+```
+
+Start the server
+```shell
+$ iex -S mix
+```
+
+#### `shawarma`
+Navigate to `/shawarma` and run `npm i`.
+
+> Mediasoup requires `node >=0.8 <=14` and has [specific requirements](https://mediasoup.org/documentation/v3/mediasoup/installation/#windows) on Windows.
+
+Create an `.env` file and set the following environment variable:
+
+```
+WEBRTC_LISTEN_IP=127.0.0.1
+```
+
+Then run `npm run build` and `npm start`.
+
+#### `kofta`
+Navigate to `/kofta` and create an `.env` file based on `.env.example`.
+
+Run `npm i` and then `npm start`.
 
 ## Investors
 


### PR DESCRIPTION
Extended the local installation instructions (although I only have tested them on macOS) and changed the current file structure for a more visual directory tree.

> Local installation instructions might need to be moved to CONTRIBUTING as README is starting to get cluttered.