### PR TITLE
Fix: Downgrade to normalize-url@4 to prevent regex bug on Safari

### DIFF
--- a/kofta/package-lock.json
+++ b/kofta/package-lock.json
@@ -10132,9 +10132,9 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.3.0.tgz",
-      "integrity": "sha512-9/nOVLYYe/dO/eJeQUNaGUF4m4Z5E7cb9oNTKabH+bNf19mqj60txTcveQxL0GlcWLXCxkOu2/LwL8oW0idIDA=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "npm-run-path": {
       "version": "2.0.2",

--- a/kofta/package.json
+++ b/kofta/package.json
@@ -13,7 +13,7 @@
     "hark": "^1.2.3",
     "jotai": "^0.12.7",
     "mediasoup-client": "^3.6.27",
-    "normalize-url": "^5.3.0",
+    "normalize-url": "^4.5.0",
     "postcss": "^8.2.4",
     "query-string": "^6.13.8",
     "react": "^17.0.1",


### PR DESCRIPTION
Solves #298. DogeHouse was breaking on Safari (macOS & iOS) due to regex lookahead and lookbehind not being supported by the browser.