### PR TITLE
Bring z-index back in header

### DIFF
--- a/kofta/src/vscode-webview/components/Backbar.tsx
+++ b/kofta/src/vscode-webview/components/Backbar.tsx
@@ -15,7 +15,7 @@ export const Backbar: React.FC<BackbarProps> = ({
   const history = useHistory();
   return (
     <div
-      className={tw`sticky top-0 flex py-4 mb-12`}
+      className={tw`sticky top-0 z-10 flex py-4 mb-12`}
       style={{
         backgroundColor: "#262626",
         borderBottom: "1px solid #808080",


### PR DESCRIPTION
Fixes #317 and reverts 498b2e2e4c6aea66af32139b6bd5612a6640c04b