### PR TITLE
Better homepage

### DIFF
--- a/kofta/src/vscode-webview/components/ListItem.tsx
+++ b/kofta/src/vscode-webview/components/ListItem.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { tw } from "twind";
+import { CheckIcon } from "../svgs/CheckIcon";
+
+interface ListItemProps {}
+
+export const ListItem: React.FC<ListItemProps> = ({ children }) => {
+  return (
+    <li className={tw`flex my-2`}>
+      <CheckIcon /><p className={tw`ml-3`}>{children}</p>
+    </li>
+  );
+};

--- a/kofta/src/vscode-webview/pages/Login.tsx
+++ b/kofta/src/vscode-webview/pages/Login.tsx
@@ -13,6 +13,7 @@ import { modalPrompt, PromptModal } from "../components/PromptModal";
 import { AlertModal } from "../components/AlertModal";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { BodyWrapper } from "../components/BodyWrapper";
+import { ListItem } from "../components/ListItem";
 
 interface LoginProps {}
 
@@ -30,22 +31,23 @@ export const Login: React.FC<LoginProps> = () => {
           <div className={tw`my-8`}>
             <Logo />
           </div>
-          <div className={tw`text-2xl`}>The home for voice conversations.</div>
-          <ul className={tw`my-4 mb-8 text-xl`}>
-            <li>- Dark theme</li>
-            <li>- Open sign ups</li>
-            <li>- Cross platform support</li>
-            <li>
-              -
+          <div className={tw`text-4xl mb-4 tracking-tight font-extrabold`}>
+            The home for voice conversations.
+          </div>
+          <ul className={tw`my-4 mb-10 text-xl`}>
+            <ListItem>Dark theme</ListItem>
+            <ListItem>Open sign ups</ListItem>
+            <ListItem>Cross platform support</ListItem>
+            <ListItem>
               <a
-                style={{ color: "var(--vscode-textLink-foreground)" }}
+                style={{ color: "var(--vscode-textLink-foreground)", padding: "0px" }}
                 href="https://github.com/benawad/dogehouse"
               >
                 Open Source
               </a>
-            </li>
-            <li>- Text chat</li>
-            <li>- Powered by Ɖoge</li>
+            </ListItem>
+            <ListItem>Text chat</ListItem>
+            <ListItem>Powered by Doge</ListItem>
           </ul>
           <div className={tw`mb-8`}>
             <Button

--- a/kofta/src/vscode-webview/svgs/CheckIcon.tsx
+++ b/kofta/src/vscode-webview/svgs/CheckIcon.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { tw } from "twind";
+
+/* SVG from heroicons, licensed under MIT https://github.com/tailwindlabs/heroicons/blob/master/LICENSE */
+export function CheckIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={tw`h-6 w-6`}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M5 13l4 4L19 7"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
Gave the elements some more room to breathe, added a new ListItem component that uses a checkmark svg instead of dashes, changed the size of the subheading.

### Mobile

| Before | After |
|:----:|:----|
|   ![dogehouse tv_(iPhone X)](https://user-images.githubusercontent.com/33849459/108649761-e2ecbb80-74b5-11eb-8408-5a46232f9651.png)   |   ![localhost_3000_(iPhone X)](https://user-images.githubusercontent.com/33849459/108649765-e4b67f00-74b5-11eb-9833-e5dae146bc9f.png)  |

### Desktop

| Before | After |
|:----:|:----|
|  ![dogehouse tv_](https://user-images.githubusercontent.com/33849459/108649816-fdbf3000-74b5-11eb-917c-f2daad3a1215.png)   |  ![localhost_3000_](https://user-images.githubusercontent.com/33849459/108649821-fef05d00-74b5-11eb-9f58-a6adea596eb2.png)  |