### PR TITLE
Fix audio element causing layout to be pushed to the right

### DIFF
--- a/kofta/src/vscode-webview/modules/room-chat/NotificationAudioRender.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/NotificationAudioRender.tsx
@@ -18,5 +18,5 @@ export const NotificationAudioRender: React.FC<NotificationAudioRenderProps> = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [iAmMentioned]);
 
-  return <audio ref={(ref) => setAudio(ref)} src="/notif.ogg" />;
+  return <audio style={{ position: 'absolute' }} ref={(ref) => setAudio(ref)} src="/notif.ogg" />;
 };


### PR DESCRIPTION
9ac2cfa356046f4d539ef5b837c32b3d5ab24b7a introduced the bug. Happens in Firefox.

<img width="1422" alt="Screenshot 2021-02-22 at 19 32 36" src="https://user-images.githubusercontent.com/57961822/108753210-b92ea580-7544-11eb-93d5-81e301a3a17c.png">
