### PR TITLE
Added optional chaining to validate peer's rectTransport, Closes #3

### DIFF
--- a/shawarma/src/index.ts
+++ b/shawarma/src/index.ts
@@ -180,7 +180,7 @@ async function main() {
           if (theirPeerId === myPeerId) {
             continue;
           }
-          const peerTransport = state[theirPeerId].recvTransport;
+          const peerTransport = state[theirPeerId]?.recvTransport;
           if (!peerTransport) {
             continue;
           }


### PR DESCRIPTION
The PR fixes a race condition that pops up when a producer transport is created. 

It adds optional chaining to make sure `recvTransport` is accessed only if needed. 

In case it doesn't exist, whenever the otherPeer's `recvTransport` is created, they'll get the respective audio consumers for this producer peer.