### PR TITLE
Fix chat styling

### DIFF
--- a/kofta/src/vscode-webview/components/Avatar.tsx
+++ b/kofta/src/vscode-webview/components/Avatar.tsx
@@ -6,6 +6,7 @@ interface AvatarProps {
   active?: boolean;
   circle?: boolean;
   usernameForErrorImg?: string;
+  className?: string;
 }
 
 export const Avatar: React.FC<AvatarProps> = ({
@@ -14,6 +15,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   active,
   circle,
   usernameForErrorImg,
+  className,
 }) => {
   const [error, setError] = useState(false);
   return (
@@ -23,7 +25,7 @@ export const Avatar: React.FC<AvatarProps> = ({
       width={size}
       height={size}
       style={active ? { boxShadow: "0 0 0 3px #60A5FA" } : undefined}
-      className={circle ? `rounded-full` : `rounded-3xl`}
+      className={`${circle ? `rounded-full` : `rounded-3xl`} ${className}`}
       src={
         error && usernameForErrorImg
           ? `https://ui-avatars.com/api/?name=${usernameForErrorImg}`

--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
@@ -28,10 +28,7 @@ export const RoomChatList: React.FC<ChatListProps> = ({}) => {
       ) : null}
       <div className={`pb-6`} />
       {messages.map((m) => (
-        <div
-          className={`flex py-1 break-all items-start`}
-          key={m.id}
-        >
+        <div className={`py-1 break-all items-start`} key={m.id}>
           <span className={`pr-2`}>
             <Avatar size={20} src={m.avatarUrl} />
           </span>
@@ -64,13 +61,11 @@ export const RoomChatList: React.FC<ChatListProps> = ({}) => {
                       setProfileId(v);
                     }}
                     key={i}
-                    className={
-                      `hover:underline flex-1 focus:outline-none ml-1 mr-2 ${
-                        v === me?.username
-                          ? "bg-simple-gray-fe text-white px-2 rounded text-md"
-                          : ""
-                      }`
-                    }
+                    className={`hover:underline flex-1 focus:outline-none ml-1 mr-2 ${
+                      v === me?.username
+                        ? "bg-blue-500 text-white px-2 rounded text-md"
+                        : ""
+                    }`}
                     style={{
                       textDecorationColor: m.color,
                       color: v === me?.username ? "" : m.color,

--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
@@ -28,9 +28,9 @@ export const RoomChatList: React.FC<ChatListProps> = ({}) => {
       ) : null}
       <div className={`pb-6`} />
       {messages.map((m) => (
-        <div className={`py-1 break-all items-start`} key={m.id}>
-          <span className={`pr-2`}>
-            <Avatar size={20} src={m.avatarUrl} />
+        <div className={`py-1 block break-all`} key={m.id}>
+          <span className={`pr-2 inline`}>
+            <Avatar size={20} src={m.avatarUrl} className="inline" />
           </span>
 
           <button
@@ -42,7 +42,6 @@ export const RoomChatList: React.FC<ChatListProps> = ({}) => {
           >
             {m.displayName}
           </button>
-
           <span className={`mr-1`}>: </span>
 
           {m.tokens.map(({ t, v }, i) => {

--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
@@ -28,7 +28,7 @@ export const RoomChatList: React.FC<ChatListProps> = ({}) => {
       ) : null}
       <div className={`pb-6`} />
       {messages.map((m) => (
-        <div className={`py-1 block break-all`} key={m.id}>
+        <div className={`py-1 block break-words`} key={m.id}>
           <span className={`pr-2 inline`}>
             <Avatar size={20} src={m.avatarUrl} className="inline" />
           </span>


### PR DESCRIPTION
Fixes #414 and #413 

(I had to pass in `className` prop to `Avatar`, otherwise, I had to use `style` attr, which we're afraid of. In this case, classes on the wrapper won't solve the issue)