### PR TITLE
feat: following online list (show offline too)

### DIFF
--- a/kofta/src/vscode-webview/components/Avatar.tsx
+++ b/kofta/src/vscode-webview/components/Avatar.tsx
@@ -7,6 +7,7 @@ interface AvatarProps {
   circle?: boolean;
   usernameForErrorImg?: string;
   className?: string;
+  isOnline?: boolean;
 }
 
 export const Avatar: React.FC<AvatarProps> = ({
@@ -16,21 +17,28 @@ export const Avatar: React.FC<AvatarProps> = ({
   circle,
   usernameForErrorImg,
   className,
+  isOnline,
 }) => {
   const [error, setError] = useState(false);
   return (
-    <img
-      alt="avatar"
-      onError={() => setError(true)}
-      width={size}
-      height={size}
-      style={active ? { boxShadow: "0 0 0 3px #60A5FA" } : undefined}
-      className={`${circle ? `rounded-full` : `rounded-3xl`} ${className}`}
-      src={
-        error && usernameForErrorImg
-          ? `https://ui-avatars.com/api/?name=${usernameForErrorImg}`
-          : src
-      }
-    />
+    <div className="relative">
+      <img
+        alt="avatar"
+        onError={() => setError(true)}
+        width={size}
+        height={size}
+        style={active ? { boxShadow: "0 0 0 3px #60A5FA" } : undefined}
+        className={`${circle ? `rounded-full` : `rounded-3xl`} ${className}`}
+        src={
+          error && usernameForErrorImg
+            ? `https://ui-avatars.com/api/?name=${usernameForErrorImg}`
+            : src
+        }
+      />
+
+      {isOnline ? (
+        <span className="rounded-full w-4 h-4 bg-green-500 absolute right-0 bottom-0"></span>
+      ) : null}
+    </div>
   );
 };

--- a/kofta/src/vscode-webview/components/Avatar.tsx
+++ b/kofta/src/vscode-webview/components/Avatar.tsx
@@ -21,7 +21,7 @@ export const Avatar: React.FC<AvatarProps> = ({
 }) => {
   const [error, setError] = useState(false);
   return (
-    <div className="relative">
+    <div className="relative inline-block">
       <img
         alt="avatar"
         onError={() => setError(true)}

--- a/kofta/src/vscode-webview/pages/FollowingOnlineList.tsx
+++ b/kofta/src/vscode-webview/pages/FollowingOnlineList.tsx
@@ -30,7 +30,7 @@ export const FollowingOnlineList: React.FC<FriendListProps> = () => {
             key={u.id}
           >
             <button onClick={() => history.push(`/user`, u)}>
-              <Avatar src={u.avatarUrl} />
+              <Avatar src={u.avatarUrl} isOnline={u.online} />
             </button>
             <button
               onClick={() => {
@@ -43,11 +43,13 @@ export const FollowingOnlineList: React.FC<FriendListProps> = () => {
               }}
               className={`ml-4 flex-1 text-left`}
             >
-              <div className={`text-lg`}>
-                {u.displayName}
-              </div>
+              <div className={`text-lg`}>{u.displayName}</div>
               <div style={{ color: "" }}>
-                {u.currentRoom ? u.currentRoom.name : "online"}
+                {u.currentRoom ? (
+                  <span>
+                    currently in: <b>{u.currentRoom.name}</b>
+                  </span>
+                ) : null}
               </div>
             </button>
             {u.followsYou ? (

--- a/kofta/src/vscode-webview/pages/FollowingOnlineList.tsx
+++ b/kofta/src/vscode-webview/pages/FollowingOnlineList.tsx
@@ -21,7 +21,7 @@ export const FollowingOnlineList: React.FC<FriendListProps> = () => {
       <Backbar />
       <BodyWrapper>
         <div className={`mb-4 text-2xl`}>
-          List of users online that are not in a private room and you follow.
+          List of users that are not in a private room and you follow.
         </div>
         {users.length === 0 ? <div>no users found</div> : null}
         {users.map((u) => (

--- a/kofta/src/vscode-webview/pages/FollowingOnlineList.tsx
+++ b/kofta/src/vscode-webview/pages/FollowingOnlineList.tsx
@@ -43,7 +43,9 @@ export const FollowingOnlineList: React.FC<FriendListProps> = () => {
               }}
               className={`ml-4 flex-1 text-left`}
             >
-              <div className={`text-lg`}>{u.displayName}</div>
+              <div className={`text-lg`}>
+                {u.displayName || "@" + u.username}
+              </div>
               <div style={{ color: "" }}>
                 {u.currentRoom ? (
                   <span>

--- a/kousa/lib/data-layer/follower_data.ex
+++ b/kousa/lib/data-layer/follower_data.ex
@@ -40,7 +40,8 @@ defmodule Kousa.Data.Follower do
                (cr.isPrivate == false and cr.numPeopleInside < ^max_room_size)),
         select: %{u | currentRoom: cr, followsYou: not is_nil(f2.userId)},
         limit: ^@fetch_limit,
-        offset: ^offset
+        offset: ^offset,
+        order_by: [desc: u.online]
       )
       |> Beef.Repo.all()
 

--- a/kousa/lib/data-layer/follower_data.ex
+++ b/kousa/lib/data-layer/follower_data.ex
@@ -35,7 +35,7 @@ defmodule Kousa.Data.Follower do
         left_join: cr in Beef.Room,
         on: u.currentRoomId == cr.id,
         where:
-          f.followerId == ^user_id and u.online == true and
+          f.followerId == ^user_id and
             (is_nil(cr.isPrivate) or
                (cr.isPrivate == false and cr.numPeopleInside < ^max_room_size)),
         select: %{u | currentRoom: cr, followsYou: not is_nil(f2.userId)},


### PR DESCRIPTION
- Show offline users that you follow (accessible via people icon from homepage)
- Sort by online in backend

![image](https://user-images.githubusercontent.com/38838675/109214952-4c313f00-77d4-11eb-8d85-9eb7f48d953b.png)
