### PR TITLE
Add space for the go home link to 404 page.

### DIFF
--- a/kofta/src/vscode-webview/pages/NotFoundPage.tsx
+++ b/kofta/src/vscode-webview/pages/NotFoundPage.tsx
@@ -16,7 +16,7 @@ export const NotFoundPage: React.FC<NotFoundPageProps> = () => {
         <div className={`text-2xl`}>
           Whoops! This page got lost in conversation.
         </div>
-        Not to worry. You can
+        Not to worry. You can 
         <Link to="/" className={`text-blue-400`}>
           go home
         </Link>


### PR DESCRIPTION
Add space for the go home link to 404 page.