### PR TITLE
Fix overflow-wrap when message has no spaces

### DIFF
--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
@@ -40,7 +40,7 @@ export const RoomChatList: React.FC<ChatListProps> = ({}) => {
       {messages.map((m) => (
         <div className="flex items-center" key={m.id}>
           <div
-            className={`py-1 block break-words items-start flex-1`}
+            className={`py-1 block break-words max-w-full items-start flex-1`}
             key={m.id}
           >
             <span className={`pr-2`}>


### PR DESCRIPTION
This PR addresses the issue #445. It simply limits the message container width to prevent the horizontal overflow.

Resolves #445 