### PR TITLE
Remove space from mentions

### DIFF
--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatInput.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatInput.tsx
@@ -55,7 +55,7 @@ export const RoomChatInput: React.FC<ChatInputProps> = () => {
       const selected = queriedUsernames[activeIndex];
       setMentions([...mentions, selected]);
       setMessage(
-        `${message.substring(0, message.lastIndexOf("@") + 1)} ${
+        `${message.substring(0, message.lastIndexOf("@") + 1)}${
           selected.username
         } `
       );

--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatMentions.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatMentions.tsx
@@ -25,6 +25,7 @@ export const RoomChatMentions: React.FC<RoomChatMentionsProps> = ({}) => {
 
   function addMention(m: BaseUser) {
     setMentions([...mentions, m]);
+
     setMessage(
       message.substring(0, message.lastIndexOf("@") + 1) + m.username + " "
     );


### PR DESCRIPTION
Mentioning users was causing multiple `@`s

![image](https://user-images.githubusercontent.com/38838675/109408033-9585b800-79a7-11eb-9552-e96818d81343.png)
