### PR TITLE
Make avatarUrl ediatble (Github/Twitter avatars only)

### DIFF
--- a/kofta/src/vscode-webview/components/EditProfileModal.tsx
+++ b/kofta/src/vscode-webview/components/EditProfileModal.tsx
@@ -17,6 +17,10 @@ const profileStruct = object({
   displayName: size(string(), 2, 50),
   username: pattern(string(), /^(\w){4,15}$/),
   bio: size(string(), 0, 160),
+  avatarUrl: pattern(
+    string(),
+    /https?:\/\/(www\.|)(pbs.twimg.com\/profile_images\/(.*)\.(jpg|png|jpeg|webp)|avatars\.githubusercontent\.com\/u\/)/
+  ),
 });
 
 interface Shared {
@@ -45,6 +49,7 @@ export const EditProfileModal: React.FC<EditProfileModalProps> = ({
             displayName: user.displayName,
             username: user.username,
             bio: user.bio,
+            avatarUrl: user.avatarUrl,
           }}
           validateOnChange={false}
           validate={validateFn}
@@ -63,6 +68,12 @@ export const EditProfileModal: React.FC<EditProfileModalProps> = ({
         >
           {({ handleSubmit }) => (
             <div>
+              <InputField
+                errorMsg="Invalid image"
+                label="Github/Twitter avatar url"
+                name="avatarUrl"
+              />
+              <FieldSpacer />
               <InputField
                 errorMsg="length 2 to 50 characters"
                 label="Display Name"

--- a/kousa/lib/beef/user.ex
+++ b/kousa/lib/beef/user.ex
@@ -46,18 +46,19 @@ defmodule Beef.User do
   end
 
   @doc false
-  def changeset(user, attrs) do
+  def changeset(user, _attrs) do
     user
     |> validate_required([:username, :githubId, :avatarUrl])
   end
 
   def edit_changeset(user, attrs) do
     user
-    |> cast(attrs, [:id, :username, :bio, :displayName])
-    |> validate_required([:username, :displayName])
+    |> cast(attrs, [:id, :username, :bio, :displayName, :avatarUrl])
+    |> validate_required([:username, :displayName, :avatarUrl])
     |> validate_length(:bio, min: 0, max: 160)
     |> validate_length(:displayName, min: 2, max: 50)
     |> validate_format(:username, ~r/^(\w){4,15}$/)
+    |> validate_format(:avatarUrl, ~r/https?:\/\/(www\.|)(pbs.twimg.com\/profile_images\/(.*)\.(jpg|png|jpeg|webp)|avatars\.githubusercontent\.com\/u\/)/)
     |> unique_constraint(:username)
   end
 end


### PR DESCRIPTION
Fixes #70
This is just a "bandaid" solution. as @benawad suggested