### PR TITLE
feat: whispers in chat

### DIFF
--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatInput.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatInput.tsx
@@ -117,7 +117,7 @@ export const RoomChatInput: React.FC<ChatInputProps> = () => {
     setMessage("");
     wsend({
       op: "send_room_chat_msg",
-      d: { tokens: createChatMessage(tmp, mentions) },
+      d: createChatMessage(tmp, mentions),
     });
     setQueriedUsernames([]);
 

--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatInput.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatInput.tsx
@@ -2,7 +2,7 @@ import { useAtom } from "jotai";
 import React, { useRef, useState } from "react";
 import { toast } from "react-toastify";
 import { wsend } from "../../../createWebsocket";
-import { meAtom } from "../../atoms";
+import { currentRoomAtom, meAtom } from "../../atoms";
 import { modalAlert } from "../../components/AlertModal";
 import { useRoomChatStore } from "./useRoomChatStore";
 import { createChatMessage } from "../../utils/createChatMessage";
@@ -25,6 +25,7 @@ export const RoomChatInput: React.FC<ChatInputProps> = () => {
     activeUsername,
     setActiveUsername,
   } = useRoomChatMentionStore();
+  const [currentRoom] = useAtom(currentRoomAtom);
   const [me] = useAtom(meAtom);
   const [isEmoji, setIsEmoji] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -115,9 +116,10 @@ export const RoomChatInput: React.FC<ChatInputProps> = () => {
 
     const tmp = message;
     setMessage("");
+
     wsend({
       op: "send_room_chat_msg",
-      d: createChatMessage(tmp, mentions),
+      d: createChatMessage(tmp, mentions, currentRoom?.users),
     });
     setQueriedUsernames([]);
 

--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
@@ -38,86 +38,101 @@ export const RoomChatList: React.FC<ChatListProps> = ({}) => {
       ) : null}
       <div className={`pb-6`} />
       {messages.map((m) => (
-        <div className="flex items-center" key={m.id}>
+        <div className="flex flex-col" key={m.id}>
+          {/* Whisper label */}
+          {m.isWhisper ? (
+            <p className="mb-0 text-xs text-gray-400 px-2 bg-simple-gray-3a w-16 rounded-t mt-1 text-center">
+              Whisper
+            </p>
+          ) : null}
+
           <div
-            className={`py-1 block break-words max-w-full items-start flex-1`}
-            key={m.id}
+            className={`flex items-center px-1 ${
+              m.isWhisper
+                ? "bg-simple-gray-3a  py-1 rounded-b-lg rounded-tr-lg mb-1"
+                : ""
+            }`}
           >
-            <span className={`pr-2`}>
-              <Avatar size={20} src={m.avatarUrl} className="inline" />
-            </span>
-
-            <button
-              onClick={() => {
-                setProfileId(m.userId);
-                setMessagetobedeleted(
-                  (me?.id === m.userId ||
-                    iAmCreator ||
-                    (iAmMod && room?.creatorId !== m.userId)) &&
-                    !m.deleted
-                    ? m
-                    : null
-                );
-              }}
-              className={`hover:underline focus:outline-none`}
-              style={{ textDecorationColor: m.color, color: m.color }}
+            <div
+              className={`py-1 block break-words max-w-full items-start flex-1`}
+              key={m.id}
             >
-              {m.displayName}
-            </button>
-
-            <span className={`mr-1`}>: </span>
-
-            {m.deleted ? (
-              <span className="text-gray-500">
-                [message {m.deleterId === m.userId ? "retracted" : "deleted"}]
+              <span className={`pr-2`}>
+                <Avatar size={20} src={m.avatarUrl} className="inline" />
               </span>
-            ) : (
-              m.tokens.map(({ t, v }, i) => {
-                switch (t) {
-                  case "text":
-                    return (
-                      <span className={`flex-1 m-0`} key={i}>
-                        {v}
-                      </span>
-                    );
 
-                  case "mention":
-                    return (
-                      <button
-                        onClick={() => {
-                          setProfileId(v);
-                        }}
-                        key={i}
-                        className={`hover:underline flex-1 focus:outline-none ml-1 mr-2 ${
-                          v === me?.username
-                            ? "bg-blue-500 text-white px-2 rounded text-md"
-                            : ""
-                        }`}
-                        style={{
-                          textDecorationColor: m.color,
-                          color: v === me?.username ? "" : m.color,
-                        }}
-                      >
-                        @{v}{" "}
-                      </button>
-                    );
-                  case "link":
-                    return (
-                      <a
-                        target="_blank"
-                        rel="noreferrer"
-                        href={v}
-                        className={`flex-1 hover:underline text-blue-500`}
-                        key={i}
-                      >
-                        {normalizeUrl(v, { stripProtocol: true })}{" "}
-                      </a>
-                    );
-                  default:
-                    return null;
-                }
-              })
-            )}
+              <button
+                onClick={() => {
+                  setProfileId(m.userId);
+                  setMessagetobedeleted(
+                    (me?.id === m.userId ||
+                      iAmCreator ||
+                      (iAmMod && room?.creatorId !== m.userId)) &&
+                      !m.deleted
+                      ? m
+                      : null
+                  );
+                }}
+                className={`hover:underline focus:outline-none`}
+                style={{ textDecorationColor: m.color, color: m.color }}
+              >
+                {m.displayName}
+              </button>
+
+              <span className={`mr-1`}>: </span>
+
+              {m.deleted ? (
+                <span className="text-gray-500">
+                  [message {m.deleterId === m.userId ? "retracted" : "deleted"}]
+                </span>
+              ) : (
+                m.tokens.map(({ t, v }, i) => {
+                  switch (t) {
+                    case "text":
+                      return (
+                        <span className={`flex-1 m-0`} key={i}>
+                          {v}
+                        </span>
+                      );
+
+                    case "mention":
+                      return (
+                        <button
+                          onClick={() => {
+                            setProfileId(v);
+                          }}
+                          key={i}
+                          className={`hover:underline flex-1 focus:outline-none ml-1 mr-2 ${
+                            v === me?.username
+                              ? "bg-blue-500 text-white px-2 rounded text-md"
+                              : ""
+                          }`}
+                          style={{
+                            textDecorationColor: m.color,
+                            color: v === me?.username ? "" : m.color,
+                          }}
+                        >
+                          @{v}{" "}
+                        </button>
+                      );
+                    case "link":
+                      return (
+                        <a
+                          target="_blank"
+                          rel="noreferrer"
+                          href={v}
+                          className={`flex-1 hover:underline text-blue-500`}
+                          key={i}
+                        >
+                          {normalizeUrl(v, { stripProtocol: true })}{" "}
+                        </a>
+                      );
+                    default:
+                      return null;
+                  }
+                })
+              )}
+            </div>
           </div>
         </div>
       ))}

--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatList.tsx
@@ -20,7 +20,7 @@ export const RoomChatList: React.FC<ChatListProps> = ({}) => {
   );
   const [
     messageToBeDeleted,
-    setMessagetobedeleted,
+    setMessageToBeDeleted,
   ] = useState<RoomChatMessage | null>(null);
 
   return (
@@ -64,7 +64,7 @@ export const RoomChatList: React.FC<ChatListProps> = ({}) => {
               <button
                 onClick={() => {
                   setProfileId(m.userId);
-                  setMessagetobedeleted(
+                  setMessageToBeDeleted(
                     (me?.id === m.userId ||
                       iAmCreator ||
                       (iAmMod && room?.creatorId !== m.userId)) &&

--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatMentions.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatMentions.tsx
@@ -36,7 +36,7 @@ export const RoomChatMentions: React.FC<RoomChatMentionsProps> = ({}) => {
 
   useEffect(() => {
     // regex to match mention patterns
-    const mentionMatches = message.match(/^(?!.*\bRT\b)(?:.+\s)?\#?@\w+/i);
+    const mentionMatches = message.match(/^(?!.*\bRT\b)(?:.+\s)?#?@\w+/i);
 
     // query usernames for matched patterns
     if (mentionMatches && me && currentRoom) {

--- a/kofta/src/vscode-webview/modules/room-chat/RoomChatMentions.tsx
+++ b/kofta/src/vscode-webview/modules/room-chat/RoomChatMentions.tsx
@@ -25,7 +25,6 @@ export const RoomChatMentions: React.FC<RoomChatMentionsProps> = ({}) => {
 
   function addMention(m: BaseUser) {
     setMentions([...mentions, m]);
-
     setMessage(
       message.substring(0, message.lastIndexOf("@") + 1) + m.username + " "
     );
@@ -37,11 +36,11 @@ export const RoomChatMentions: React.FC<RoomChatMentionsProps> = ({}) => {
 
   useEffect(() => {
     // regex to match mention patterns
-    const mentionMatches = message.match(/^(?!.*\bRT\b)(?:.+\s)?@\w+/i);
+    const mentionMatches = message.match(/^(?!.*\bRT\b)(?:.+\s)?\#?@\w+/i);
 
     // query usernames for matched patterns
     if (mentionMatches && me && currentRoom) {
-      const mentionsList = mentionMatches[0].replace(/@/g, "").split(" ");
+      const mentionsList = mentionMatches[0].replace(/@|#/g, "").split(" ");
       const useMention = mentionsList[mentionsList.length - 1];
 
       // hide usernames list if user continues typing without selecting

--- a/kofta/src/vscode-webview/modules/room-chat/useRoomChatStore.ts
+++ b/kofta/src/vscode-webview/modules/room-chat/useRoomChatStore.ts
@@ -45,6 +45,7 @@ export interface RoomChatMessage {
   tokens: RoomChatMessageToken[];
   deleted?: boolean;
   deleterId?: string;
+  isWhisper?: boolean;
 }
 
 export const useRoomChatStore = create(

--- a/kofta/src/vscode-webview/utils/createChatMessage.ts
+++ b/kofta/src/vscode-webview/utils/createChatMessage.ts
@@ -11,16 +11,19 @@ export const createChatMessage = (message: string, mentions: BaseUser[]) => {
     }
   ];
 
+  let whisperedFor: string | null = null;
+
   message.split(" ").forEach((item) => {
     const isLink = linkRegex.test(item);
-    const isMention = mentions.find(
-      (m) => item.replace("@", "") === m.username
-    );
+    const withoutAt = item.replace(/@|#/g, "");
+    const isMention = mentions.find((m) => withoutAt === m.username);
+    const isWhisper = isMention && item.indexOf("#@") === 0;
+    whisperedFor || (whisperedFor = isWhisper ? withoutAt : null);
 
     if (isLink || isMention) {
       tokens.push({
         t: isLink ? "link" : "mention",
-        v: isMention ? item.replace("@", "") : normalizeUrl(item),
+        v: isMention ? withoutAt : normalizeUrl(item),
       });
     } else {
       const lastToken = tokens[tokens.length - 1];
@@ -35,5 +38,8 @@ export const createChatMessage = (message: string, mentions: BaseUser[]) => {
     }
   });
 
-  return tokens;
+  return {
+    tokens,
+    whisperedFor,
+  };
 };

--- a/kofta/src/vscode-webview/utils/createChatMessage.ts
+++ b/kofta/src/vscode-webview/utils/createChatMessage.ts
@@ -1,9 +1,14 @@
 import { linkRegex } from "./../constants";
 import { BaseUser } from "../types";
+
 // @ts-ignore
 import normalizeUrl from "normalize-url";
 
-export const createChatMessage = (message: string, mentions: BaseUser[]) => {
+export const createChatMessage = (
+  message: string,
+  mentions: BaseUser[],
+  roomUsers: BaseUser[] = []
+) => {
   const tokens = ([] as unknown) as [
     {
       t: string;
@@ -11,14 +16,14 @@ export const createChatMessage = (message: string, mentions: BaseUser[]) => {
     }
   ];
 
-  let whisperedFor: string | null = null;
+  let whisperedToUsername: string | null = null;
 
   message.split(" ").forEach((item) => {
     const isLink = linkRegex.test(item);
     const withoutAt = item.replace(/@|#/g, "");
     const isMention = mentions.find((m) => withoutAt === m.username);
     const isWhisper = isMention && item.indexOf("#@") === 0;
-    whisperedFor || (whisperedFor = isWhisper ? withoutAt : null);
+    whisperedToUsername || (whisperedToUsername = isWhisper ? withoutAt : null);
 
     if (isLink || isMention) {
       tokens.push({
@@ -40,6 +45,10 @@ export const createChatMessage = (message: string, mentions: BaseUser[]) => {
 
   return {
     tokens,
-    whisperedFor,
+    whisperedTo:
+      roomUsers.find(
+        (u) =>
+          u.username?.toLowerCase() === whisperedToUsername?.toLocaleLowerCase()
+      )?.id || null,
   };
 };

--- a/kofta/src/vscode-webview/utils/createChatMessage.ts
+++ b/kofta/src/vscode-webview/utils/createChatMessage.ts
@@ -46,17 +46,6 @@ export const createChatMessage = (
     }
   });
 
-  console.log({
-    tokens,
-    whisperedTo: roomUsers
-      .filter((u) =>
-        whisperedToUsernames
-          .map((u) => u?.toLowerCase())
-          .includes(u.username?.toLowerCase())
-      )
-      .map((u) => u.id),
-  });
-
   return {
     tokens,
     whisperedTo: roomUsers

--- a/kofta/src/vscode-webview/utils/createChatMessage.ts
+++ b/kofta/src/vscode-webview/utils/createChatMessage.ts
@@ -16,14 +16,17 @@ export const createChatMessage = (
     }
   ];
 
-  let whisperedToUsername: string | null = null;
+  const whisperedToUsernames: string[] = [];
 
   message.split(" ").forEach((item) => {
     const isLink = linkRegex.test(item);
     const withoutAt = item.replace(/@|#/g, "");
     const isMention = mentions.find((m) => withoutAt === m.username);
-    const isWhisper = isMention && item.indexOf("#@") === 0;
-    whisperedToUsername || (whisperedToUsername = isWhisper ? withoutAt : null);
+
+    // whisperedTo users list
+    !isMention ||
+      item.indexOf("#@") !== 0 ||
+      whisperedToUsernames.push(withoutAt);
 
     if (isLink || isMention) {
       tokens.push({
@@ -43,12 +46,25 @@ export const createChatMessage = (
     }
   });
 
+  console.log({
+    tokens,
+    whisperedTo: roomUsers
+      .filter((u) =>
+        whisperedToUsernames
+          .map((u) => u?.toLowerCase())
+          .includes(u.username?.toLowerCase())
+      )
+      .map((u) => u.id),
+  });
+
   return {
     tokens,
-    whisperedTo:
-      roomUsers.find(
-        (u) =>
-          u.username?.toLowerCase() === whisperedToUsername?.toLocaleLowerCase()
-      )?.id || null,
+    whisperedTo: roomUsers
+      .filter((u) =>
+        whisperedToUsernames
+          .map((u) => u?.toLowerCase())
+          .includes(u.username?.toLowerCase())
+      )
+      .map((u) => u.id),
   };
 };

--- a/kousa/lib/business-logic/room_chat_logic.ex
+++ b/kousa/lib/business-logic/room_chat_logic.ex
@@ -3,7 +3,7 @@ defmodule Kousa.BL.RoomChat do
 
   @message_character_limit 512
 
-  @spec send_msg(String.t(), list(map), String.t()) :: any
+  @spec send_msg(String.t(), list(map), list(String.t())) :: any
   def send_msg(user_id, tokens, whispered_to) do
     tokens = validate_tokens(tokens)
     if length(tokens) > 0 do
@@ -24,7 +24,7 @@ defmodule Kousa.BL.RoomChat do
                  displayName: display_name,
                  userId: user_id,
                  tokens: tokens,
-                 isWhisper: !!whispered_to
+                 isWhisper: whispered_to != []
                }, whispered_to}
             )
           end

--- a/kousa/lib/business-logic/room_chat_logic.ex
+++ b/kousa/lib/business-logic/room_chat_logic.ex
@@ -3,10 +3,9 @@ defmodule Kousa.BL.RoomChat do
 
   @message_character_limit 512
 
-  @spec send_msg(String.t(), list(map)) :: any
-  def send_msg(user_id, tokens) do
+  @spec send_msg(String.t(), list(map), String.t()) :: any
+  def send_msg(user_id, tokens, whispered_to) do
     tokens = validate_tokens(tokens)
-
     if length(tokens) > 0 do
       case Data.User.get_current_room_id(user_id) do
         nil ->
@@ -24,8 +23,9 @@ defmodule Kousa.BL.RoomChat do
                  avatarUrl: avatar_url,
                  displayName: display_name,
                  userId: user_id,
-                 tokens: tokens
-               }}
+                 tokens: tokens,
+                 isWhisper: !!whispered_to
+               }, whispered_to}
             )
           end
       end

--- a/kousa/lib/gen/room_chat.ex
+++ b/kousa/lib/gen/room_chat.ex
@@ -65,8 +65,7 @@ defmodule Kousa.Gen.RoomChat do
 
     if not Map.has_key?(state.ban_map, user_id) and
       (is_nil(last_timestamp) or seconds - last_timestamp > 0) do
-      users = if whispered_to, do: Enum.filter(state.users, fn uid -> uid == whispered_to end), else: state.users
-
+      users = if whispered_to != [], do: Enum.filter(state.users, fn uid -> Enum.member?([user_id] ++ whispered_to, uid) end), else: state.users
       ws_fan(users, :chat, %{
         op: "new_chat_msg",
         d: %{

--- a/kousa/lib/gen/room_chat.ex
+++ b/kousa/lib/gen/room_chat.ex
@@ -65,17 +65,19 @@ defmodule Kousa.Gen.RoomChat do
 
     if not Map.has_key?(state.ban_map, user_id) and
       (is_nil(last_timestamp) or seconds - last_timestamp > 0) do
-      users = if whispered_to != [], do: Enum.filter(state.users, fn uid -> Enum.member?([user_id] ++ whispered_to, uid) end), else: state.users
-      ws_fan(users, :chat, %{
-        op: "new_chat_msg",
-        d: %{
-          userId: user_id,
-          msg: msg
-        }
-      })
 
-      {:noreply,
-       %State{state | last_message_map: Map.put(state.last_message_map, user_id, seconds)}}
+        whispered_to_users_list = [user_id | whispered_to]
+        users = if whispered_to != [], do: Enum.filter(state.users, fn uid -> Enum.member?(whispered_to_users_list, uid) end), else: state.users
+        ws_fan(users, :chat, %{
+          op: "new_chat_msg",
+          d: %{
+            userId: user_id,
+            msg: msg
+          }
+        })
+
+        {:noreply,
+        %State{state | last_message_map: Map.put(state.last_message_map, user_id, seconds)}}
     else
       {:noreply, state}
     end

--- a/kousa/lib/gen/room_chat.ex
+++ b/kousa/lib/gen/room_chat.ex
@@ -59,13 +59,15 @@ defmodule Kousa.Gen.RoomChat do
     {:noreply, state}
   end
 
-  def handle_cast({:new_msg, user_id, msg}, %State{} = state) do
+  def handle_cast({:new_msg, user_id, msg, whispered_to}, %State{} = state) do
     last_timestamp = Map.get(state.last_message_map, user_id)
     {_, seconds, _} = :os.timestamp()
 
     if not Map.has_key?(state.ban_map, user_id) and
-         (is_nil(last_timestamp) or seconds - last_timestamp > 0) do
-      ws_fan(state.users, :chat, %{
+      (is_nil(last_timestamp) or seconds - last_timestamp > 0) do
+      users = if whispered_to, do: Enum.filter(state.users, fn uid -> uid == whispered_to end), else: state.users
+
+      ws_fan(users, :chat, %{
         op: "new_chat_msg",
         d: %{
           userId: user_id,

--- a/kousa/lib/socket_handler.ex
+++ b/kousa/lib/socket_handler.ex
@@ -402,8 +402,8 @@ defmodule Kousa.SocketHandler do
     {:ok, state}
   end
 
-  def handler("send_room_chat_msg", %{"tokens" => tokens}, state) do
-    Kousa.BL.RoomChat.send_msg(state.user_id, tokens)
+  def handler("send_room_chat_msg", %{"tokens" => tokens, "whisperedTo" => whispered_to}, state) do
+    Kousa.BL.RoomChat.send_msg(state.user_id, tokens, whispered_to)
     {:ok, state}
   end
 


### PR DESCRIPTION
Fixes #402

You can now chat with other users privately in the room group chat. We call this _whispering_, thanks to _James-Baloyi_ 

Previously, users were mentioned by putting an `@` before the username and selecting the user from the list. 

To whisper, put `#@` before selecting the user from the user list. This will only send the message to usernames that were mentioned using a `#@` before the username.

A working demo:

https://user-images.githubusercontent.com/38838675/109415336-d5fe2980-79d9-11eb-81b8-78a490a48e66.mp4



  