### PR TITLE
Permissions error dismiss

### DIFF
--- a/kofta/src/vscode-webview/components/MicPermissionBanner.tsx
+++ b/kofta/src/vscode-webview/components/MicPermissionBanner.tsx
@@ -7,7 +7,7 @@ import { Button } from "./Button";
 interface MicPermissionBannerProps {}
 
 export const MicPermissionBanner: React.FC<MicPermissionBannerProps> = () => {
-  const { error } = useMicPermErrorStore();
+  const { error, set } = useMicPermErrorStore();
   const [count, setCount] = useState(0);
   if (!error) {
     return null;
@@ -18,18 +18,23 @@ export const MicPermissionBanner: React.FC<MicPermissionBannerProps> = () => {
         Permission denied trying to access your mic (you may need to go into
         browser settings and reload the page)
       </div>
-      <Button
-        onClick={() => {
-          if (count < 2 && !isIOS()) {
-            sendVoice();
-            setCount((c) => c + 1);
-          } else {
-            window.location.reload();
-          }
-        }}
-      >
-        try again
-      </Button>
+      <div className="flex space-x-2">
+        <Button color="secondary" onClick={() => set({ error: false })}>
+          dismiss
+        </Button>
+        <Button
+          onClick={() => {
+            if (count < 2 && !isIOS()) {
+              sendVoice();
+              setCount((c) => c + 1);
+            } else {
+              window.location.reload();
+            }
+          }}
+        >
+          try again
+        </Button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
* Adds dismiss button to permissions error banner
* Automatically dismisses error banner when user navigates to a new page

Fixes https://github.com/benawad/dogehouse/issues/465

![image](https://user-images.githubusercontent.com/8216227/109421536-12c92100-79d8-11eb-8b6f-63851383c16a.png)
