### PR TITLE
Remove tokens-only handler so whisper handler catches the request

### DIFF
--- a/kousa/lib/socket_handler.ex
+++ b/kousa/lib/socket_handler.ex
@@ -400,11 +400,6 @@ defmodule Kousa.SocketHandler do
     {:ok, state}
   end
 
-  def handler("send_room_chat_msg", %{"tokens" => tokens}, state) do
-    Kousa.BL.RoomChat.send_msg(state.user_id, tokens, [])
-    {:ok, state}
-  end
-
   def handler("send_room_chat_msg", %{"tokens" => tokens, "whisperedTo" => whispered_to}, state) do
     Kousa.BL.RoomChat.send_msg(state.user_id, tokens, whispered_to)
     {:ok, state}


### PR DESCRIPTION
Somehow the chat message div has reversed `flex`. And deleted the token-only handler completey.