### PR TITLE
Fix spanish translation

### DIFF
--- a/kofta/public/locales/es/translation.json
+++ b/kofta/public/locales/es/translation.json
@@ -93,7 +93,7 @@
 			"leaveCurrentRoomBtn": "Abandonar sala actual",
 			"confirmLeaveRoom": "¿Estás seguro de que quieres irte?",
 			"leave": "Abandonar",
-			"inviteUsersToRoomBtn": "Invitar usuarios a la sala,
+			"inviteUsersToRoomBtn": "Invitar usuarios a la sala",
 			"invite": "Invitar",
 			"toggleMuteMicBtn": "Alternar silenciar micrófono",
 			"mute": "Silenciar",


### PR DESCRIPTION
Spanish translation was not displayed correctly in the previous version.