### PR TITLE
Issue #553 - Reposition login buttons and links on desktop mode

### DIFF
--- a/kofta/src/app/components/Footer.tsx
+++ b/kofta/src/app/components/Footer.tsx
@@ -11,7 +11,7 @@ export const Footer: React.FC<FooterProps> = ({ isLogin }) => {
 	const { t } = useTypeSafeTranslation();
 
 	return (
-		<div className={`justify-around flex text-center`}>
+		<div className={`justify-between flex text-center`}>
 			{isLogin ? (
 				<RegularAnchor href="https://www.youtube.com/watch?v=hy-EhJ_tTQo">
 					{t("footer.link_1")}


### PR DESCRIPTION
The login buttons were made wider and the links were spaced out to match the alignment of the rest of the content on the login page. See attached screenshot to result.
![Screen Shot 2021-03-06 at 5 07 10 AM](https://user-images.githubusercontent.com/70864612/110207660-da8f6b80-7e39-11eb-8f19-227fa49a53d7.png)

