### PR TITLE
Fixes #636 - Scheduled meetings have wrong date

### DIFF
--- a/kofta/public/locales/de/translation.json
+++ b/kofta/public/locales/de/translation.json
@@ -13,7 +13,8 @@
 		"joinRoom": "Raum beitreten",
 		"copyLink": "Link kopieren",
 		"copied": "kopiert",
-		"formattedIntlDate": "{{date, intlDate}}"
+		"formattedIntlDate": "{{date, intlDate}}",
+		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {
 		"_comment": "Main Header UI Internationalization Strings",

--- a/kofta/public/locales/en/translation.json
+++ b/kofta/public/locales/en/translation.json
@@ -14,7 +14,8 @@
 		"joinRoom": "join room",
 		"copyLink": "copy link",
 		"copied": "copied",
-		"formattedIntlDate": "{{date, intlDate}}"
+		"formattedIntlDate": "{{date, intlDates}}",
+		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {
 		"_comment": "Main Header UI Internationalization Strings",

--- a/kofta/public/locales/en/translation.json
+++ b/kofta/public/locales/en/translation.json
@@ -14,7 +14,7 @@
 		"joinRoom": "join room",
 		"copyLink": "copy link",
 		"copied": "copied",
-		"formattedIntlDate": "{{date, intlDates}}",
+		"formattedIntlDate": "{{date, intlDate}}",
 		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {

--- a/kofta/public/locales/es/translation.json
+++ b/kofta/public/locales/es/translation.json
@@ -13,7 +13,8 @@
 		"joinRoom": "join room",
 		"copyLink": "copy link",
 		"copied": "copied",
-		"formattedIntlDate": "{{date, intlDate}}"
+		"formattedIntlDate": "{{date, intlDate}}",
+		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {
 		"_comment": "Main Header UI Internationalization Strings",

--- a/kofta/public/locales/fr/translation.json
+++ b/kofta/public/locales/fr/translation.json
@@ -13,7 +13,8 @@
 		"joinRoom": "join room",
 		"copyLink": "copy link",
 		"copied": "copied",
-		"formattedIntlDate": "{{date, intlDate}}"
+		"formattedIntlDate": "{{date, intlDate}}",
+		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {
 		"_comment": "Main Header UI Internationalization Strings",

--- a/kofta/public/locales/hu/translation.json
+++ b/kofta/public/locales/hu/translation.json
@@ -13,7 +13,8 @@
 		"joinRoom": "join room",
 		"copyLink": "copy link",
 		"copied": "copied",
-		"formattedIntlDate": "{{date, intlDate}}"
+		"formattedIntlDate": "{{date, intlDate}}",
+		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {
 		"_comment": "Main Header UI Internationalization Strings",

--- a/kofta/public/locales/nb/translation.json
+++ b/kofta/public/locales/nb/translation.json
@@ -13,7 +13,8 @@
 		"joinRoom": "bli med i rommet",
 		"copyLink": "kopier link",
 		"copied": "kopiert",
-		"formattedIntlDate": "{{date, intlDate}}"
+		"formattedIntlDate": "{{date, intlDate}}",
+		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {
 		"_comment": "Main Header UI Internationalization Strings",

--- a/kofta/public/locales/pt-BR/translation.json
+++ b/kofta/public/locales/pt-BR/translation.json
@@ -14,7 +14,8 @@
 		"joinRoom": "join room",
 		"copyLink": "copy link",
 		"copied": "copied",
-		"formattedIntlDate": "{{date, intlDate}}"
+		"formattedIntlDate": "{{date, intlDate}}",
+		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {
 		"_comment": "Cabeçalho da interface principal para traduções",

--- a/kofta/public/locales/pt-PT/translation.json
+++ b/kofta/public/locales/pt-PT/translation.json
@@ -13,7 +13,8 @@
 		"joinRoom": "entrar na sala",
 		"copyLink": "copiar link",
 		"copied": "copiado",
-		"formattedIntlDate": "{{date, intlDate}}"
+		"formattedIntlDate": "{{date, intlDate}}",
+		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {
 		"_comment": "Main Header UI Internationalization Strings",

--- a/kofta/public/locales/tr/translation.json
+++ b/kofta/public/locales/tr/translation.json
@@ -13,7 +13,8 @@
 		"joinRoom": "Odaya katıl",
 		"copyLink": "Linki kopyala",
 		"copied": "Kopyalandı!",
-		"formattedIntlDate": "{{date, intlDate}}"
+		"formattedIntlDate": "{{date, intlDate}}",
+		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {
 		"_comment": "Ana başlık arayüz ulusallaştırma yazıları",

--- a/kofta/public/locales/zh-CN/translation.json
+++ b/kofta/public/locales/zh-CN/translation.json
@@ -13,7 +13,8 @@
 		"joinRoom": "加入音频聊天室",
 		"copyLink": "拷贝链接",
 		"copied": "已拷贝",
-		"formattedIntlDate": "{{date, intlDate}}"
+		"formattedIntlDate": "{{date, intlDate}}",
+		"formattedIntlTime": "{{time, intlTime}}"
 	},
 	"header": {
 		"_comment": "Main Header UI Internationalization Strings",

--- a/kofta/src/app/modules/scheduled-rooms/ScheduledRoomCard.tsx
+++ b/kofta/src/app/modules/scheduled-rooms/ScheduledRoomCard.tsx
@@ -78,7 +78,7 @@ export const ScheduledRoomCard: React.FC<ScheduledRoomCardProps> = ({
 						<div>
 							{isToday(dt)
 								? format(dt, `K:mm a`)
-								: format(dt, `MM/dd/yyyy K:mm a`)}
+								: t("common.formattedIntlDate", {"date": dt})}
 						</div>
 						<AddToCalendarButton
 							event={{

--- a/kofta/src/app/modules/scheduled-rooms/ScheduledRoomCard.tsx
+++ b/kofta/src/app/modules/scheduled-rooms/ScheduledRoomCard.tsx
@@ -1,4 +1,4 @@
-import { differenceInMilliseconds, format, isPast, isToday } from "date-fns";
+import { differenceInMilliseconds, isPast, isToday } from "date-fns";
 import React, { useEffect, useMemo, useState } from "react";
 import { useMutation } from "react-query";
 import { useHistory } from "react-router-dom";
@@ -77,8 +77,9 @@ export const ScheduledRoomCard: React.FC<ScheduledRoomCardProps> = ({
 					<div className={`flex justify-between`}>
 						<div>
 							{isToday(dt)
-								? format(dt, `K:mm a`)
-								: t("common.formattedIntlDate", {"date": dt})}
+								? t("common.formattedIntlTime", { time: dt })
+								: t("common.formattedIntlDate", { date: dt })
+							}
 						</div>
 						<AddToCalendarButton
 							event={{

--- a/kofta/src/app/utils/useTypeSafeTranslation.ts
+++ b/kofta/src/app/utils/useTypeSafeTranslation.ts
@@ -1,10 +1,15 @@
 import { useTranslation } from "react-i18next";
 import { TranslationKeys } from "../../generated/translationKeys";
 
+interface DateTranslationType {
+	time?: Date,
+	date?: Date
+}
+
 export const useTypeSafeTranslation = () => {
 	const { t } = useTranslation();
 
 	return {
-		t: (s: TranslationKeys, f?: {}) => t(s, f)
+		t: (s: TranslationKeys, f?: DateTranslationType) => t(s, f)
 	};
 };

--- a/kofta/src/app/utils/useTypeSafeTranslation.ts
+++ b/kofta/src/app/utils/useTypeSafeTranslation.ts
@@ -5,6 +5,6 @@ export const useTypeSafeTranslation = () => {
 	const { t } = useTranslation();
 
 	return {
-		t: (s: TranslationKeys, f?: String) => t(s, f),
+		t: (s: TranslationKeys, f?: {}) => t(s, f)
 	};
 };

--- a/kofta/src/generated/translationKeys.ts
+++ b/kofta/src/generated/translationKeys.ts
@@ -14,6 +14,7 @@ export type TranslationKeys =
 	| "common.copyLink"
 	| "common.copied"
 	| "common.formattedIntlDate"
+	| "common.formattedIntlTime"
 	| "header.title"
 	| "header.mutedTitle"
 	| "footer.link_1"

--- a/kofta/src/i18n.ts
+++ b/kofta/src/i18n.ts
@@ -3,6 +3,7 @@ import Backend from "i18next-http-backend";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 import { __prod__ } from "./app/constants";
+import { isDate } from "lodash";
 
 export const init_i18n = () => {
 	i18n
@@ -20,14 +21,9 @@ export const init_i18n = () => {
 			interpolation: {
 				escapeValue: false,
 				format: (value, format, lng) => {
-					if (format === 'intlDate') {
-						return new Intl.DateTimeFormat(lng, {
-							year: 'numeric', month: 'numeric', day: 'numeric',
-							hour: 'numeric', minute: 'numeric'
-						}).format(value).toString();
-					}
-
-					return value;
+					return isDate(value) && format ? new Intl.DateTimeFormat(lng,
+						createDateFormatOptions(format)).format(value).toString()
+						: value;
 				}
 			},
 			react: {
@@ -35,3 +31,28 @@ export const init_i18n = () => {
 			},
 		});
 };
+
+function createDateFormatOptions(format: string): Intl.DateTimeFormatOptions {
+	switch (format) {
+		case 'intlDate': {
+			// EN returns 3/16/2021, 5:45 PM
+			return {
+				year: 'numeric', month: 'numeric', day: 'numeric',
+				hour: 'numeric', minute: 'numeric'
+			}
+		}
+		case 'intlTime': {
+			// EN returns 05:45 PM
+			return {
+				hour: 'numeric', minute: 'numeric'
+			}
+		}
+		default: {
+			// EN returns Tuesday, March 16, 2021, 5:45 PM
+			return {
+				weekday: 'long', year: 'numeric', month: 'long',
+				day: 'numeric', hour: 'numeric', minute: 'numeric'
+			}
+		}
+	}
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19981656/110267878-ac6f7000-7f8e-11eb-80f2-9ea2deb84aa9.png)

- Dates are now showing correctly.
- Issue related to how interop works, had to pass as object to t()
- Added time translation too so that if it's just time you want displayed, it will display it based on language selection.

Closes #636 