### PR TITLE
Change All CRLF line endings to LF endings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dogehouse",
+  "name": "dogehouse-fork",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
The ESLint was configures to only like LF endings but literally every file (even `.storybook/` files) had CRLF endings.

PR changes it to LF