### PR TITLE
Hotkeys for toggle-mute, push-to-talk, and toggle-chat

### DIFF
--- a/kofta/src/app/components/BottomVoiceControl.tsx
+++ b/kofta/src/app/components/BottomVoiceControl.tsx
@@ -23,6 +23,7 @@ import { modalConfirm } from "./ConfirmModal";
 import { Footer } from "./Footer";
 import { RoomSettingsModal } from "./RoomSettingsModal";
 import { useTypeSafeTranslation } from "../utils/useTypeSafeTranslation";
+import { KeybindListener } from './KeybindListener';
 
 interface BottomVoiceControlProps {}
 
@@ -217,7 +218,10 @@ export const BottomVoiceControl: React.FC<BottomVoiceControlProps> = ({
 					className={`border-simple-gray-80 bg-simple-gray-26 border-t w-full mt-auto p-5`}
 				>
 					{currentRoom ? (
-						<div className={`flex justify-around`}>{buttons}</div>
+						<>
+							<KeybindListener />
+							<div className={`flex justify-around`}>{buttons}</div>
+						</>
 					) : (
 						<div className={`px-5`}>
 							<Footer />

--- a/kofta/src/app/components/KeybindListener.tsx
+++ b/kofta/src/app/components/KeybindListener.tsx
@@ -3,11 +3,16 @@ import { GlobalHotKeys } from "react-hotkeys";
 import { wsend } from "../../createWebsocket";
 import { useKeyMapStore } from "../../webrtc/stores/useKeyMapStore";
 import { useMuteStore } from "../../webrtc/stores/useMuteStore";
+import { useRoomChatStore } from "../modules/room-chat/useRoomChatStore";
 
 interface KeybindListenerProps {}
 
 export const KeybindListener: React.FC<KeybindListenerProps> = ({}) => {
   const { keyMap } = useKeyMapStore();
+	const [toggleOpen, newUnreadMessages] = useRoomChatStore((s) => [
+		s.toggleOpen,
+		s.newUnreadMessages,
+	]);
 
   return (
     <GlobalHotKeys
@@ -34,6 +39,7 @@ export const KeybindListener: React.FC<KeybindListenerProps> = ({}) => {
             });
             setMute(mute);
           },
+          CHAT: toggleOpen,
         }),
         []
       )}

--- a/kofta/src/app/components/VoiceSettings.tsx
+++ b/kofta/src/app/components/VoiceSettings.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { volumeAtom } from "../shared-atoms";
 import { useMicIdStore } from "../shared-stores";
 import { Button } from "./Button";
-import { MuteKeybind, PTTKeybind } from "./keyboard-shortcuts";
+import { MuteKeybind, PTTKeybind, ChatKeybind } from "./keyboard-shortcuts";
 import { VolumeSlider } from "./VolumeSlider";
 import { useTypeSafeTranslation } from "../utils/useTypeSafeTranslation";
 
@@ -71,7 +71,8 @@ export const VoiceSettings: React.FC<VoiceSettingsProps> = () => {
 				<VolumeSlider volume={volume} onVolume={(n) => setVolume(n)} />
 			</div>
 			<MuteKeybind className={`mb-4`} />
-			<PTTKeybind />
+			<PTTKeybind className={`mb-4`} />
+			<ChatKeybind />
 		</>
 	);
 };

--- a/kofta/src/app/components/keyboard-shortcuts/ChatKeybind.tsx
+++ b/kofta/src/app/components/keyboard-shortcuts/ChatKeybind.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { recordKeyCombination } from "react-hotkeys";
+import { useKeyMapStore } from "../../../webrtc/stores/useKeyMapStore";
+import { Button } from "../Button";
+
+interface ChatKeybindProps {
+  className?: string;
+}
+
+export const ChatKeybind: React.FC<ChatKeybindProps> = ({ className }) => {
+  const [count, setCount] = useState(0);
+  const [active, setActive] = useState(false);
+  const {
+    keyNames: { CHAT },
+    setChatKeybind,
+  } = useKeyMapStore();
+  useEffect(() => {
+    if (count > 0) {
+      const unsub = recordKeyCombination(({ id }) => {
+        setActive(false);
+        setChatKeybind(id as string);
+      });
+
+      return () => unsub();
+    }
+  }, [count, setChatKeybind]);
+
+  return (
+    <div className={`flex items-center ${className}`}>
+      <Button
+        variant="small"
+        onClick={() => {
+          setCount((c) => c + 1);
+          setActive(true);
+        }}
+      >
+        set keybind
+      </Button>
+      <div className={`ml-4`}>
+        toggle chat keybind:{" "}
+        <span className={`font-bold text-lg`}>
+          {active ? "listening" : CHAT}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/kofta/src/app/components/keyboard-shortcuts/index.ts
+++ b/kofta/src/app/components/keyboard-shortcuts/index.ts
@@ -1,2 +1,3 @@
-export {MuteKeybind} from './MuteKeybind'
+export { MuteKeybind } from './MuteKeybind'
+export { ChatKeybind } from './ChatKeybind'
 export { PTTKeybind } from './PTTKeybind'

--- a/kofta/src/webrtc/stores/useKeyMapStore.ts
+++ b/kofta/src/webrtc/stores/useKeyMapStore.ts
@@ -3,6 +3,7 @@ import create from "zustand";
 import { combine } from "zustand/middleware";
 
 const MUTE_KEY = "@keybind/mute";
+const CHAT_KEY = "@keybind/chat";
 const PTT_KEY = "@keybind/ptt";
 
 function getMuteKeybind() {
@@ -12,6 +13,15 @@ function getMuteKeybind() {
   } catch {}
 
   return v || "Control+m";
+}
+
+function getChatKeybind() {
+  let v = "";
+  try {
+    v = localStorage.getItem(CHAT_KEY) || "";
+  } catch {}
+
+  return v || "c";
 }
 
 function getPTTKeybind() {
@@ -25,6 +35,7 @@ function getPTTKeybind() {
 
 const keyMap: KeyMap = {
   MUTE: getMuteKeybind(),
+  CHAT: getChatKeybind(),
   PTT: [
     { sequence: getPTTKeybind(), action: "keydown" },
     { sequence: getPTTKeybind(), action: "keyup" },
@@ -33,6 +44,7 @@ const keyMap: KeyMap = {
 
 const keyNames: KeyMap = {
   MUTE: getMuteKeybind(),
+  CHAT: getChatKeybind(),
   PTT: getPTTKeybind(),
 };
 
@@ -50,6 +62,15 @@ export const useKeyMapStore = create(
         set(x => ({
           keyMap: { ...x.keyMap, MUTE: id },
           keyNames: { ...x.keyNames, MUTE: id },
+        }));
+      },
+      setChatKeybind: (id: string) => {
+        try {
+          localStorage.setItem(CHAT_KEY, id);
+        } catch {}
+        set(x => ({
+          keyMap: { ...x.keyMap, CHAT: id },
+          keyNames: { ...x.keyNames, CHAT: id },
         }));
       },
       setPTTKeybind: (id: string) => {


### PR DESCRIPTION
Render keybind listeners for toggle-mute, push-to-talk, and toggle-chat to bottom voice control when user is in a room.

Default keybinds are:
- `Control+m` for toggle-mute
- `0` for push-to-talk
- `c` for toggle-chat

These keybinds can be changed in voice settings.