### PR TITLE
Stop long description text from breaking Scheduled Room Card UI.

### DIFF
--- a/kofta/src/app/modules/scheduled-rooms/ScheduledRoomCard.tsx
+++ b/kofta/src/app/modules/scheduled-rooms/ScheduledRoomCard.tsx
@@ -134,7 +134,7 @@ export const ScheduledRoomCard: React.FC<ScheduledRoomCardProps> = ({
 							<CopyScheduleRoomLinkButton text={url} />
 						)}
 					</div>
-					<div>
+					<div className={`break-all`}>
 						{creator.displayName}
 						{description ? ` | ` + description : ``}
 					</div>


### PR DESCRIPTION
Stop display name and long description text from overflowing and breaking Scheduled Room Card UI.

![image](https://user-images.githubusercontent.com/8153623/110352762-eb87da80-7ffb-11eb-8515-5d8444a7b8f5.png)