### PR TITLE
Add invite and request-to-speak hotkeys

### DIFF
--- a/kofta/src/app/components/KeybindListener.tsx
+++ b/kofta/src/app/components/KeybindListener.tsx
@@ -4,6 +4,8 @@ import { wsend } from "../../createWebsocket";
 import { useKeyMapStore } from "../../webrtc/stores/useKeyMapStore";
 import { useMuteStore } from "../../webrtc/stores/useMuteStore";
 import { useRoomChatStore } from "../modules/room-chat/useRoomChatStore";
+import { useHistory } from "react-router-dom";
+import { modalConfirm } from "../components/ConfirmModal";
 
 interface KeybindListenerProps {}
 
@@ -13,6 +15,7 @@ export const KeybindListener: React.FC<KeybindListenerProps> = ({}) => {
 		s.toggleOpen,
 		s.newUnreadMessages,
 	]);
+  const history = useHistory();
 
   return (
     <GlobalHotKeys
@@ -20,6 +23,11 @@ export const KeybindListener: React.FC<KeybindListenerProps> = ({}) => {
       keyMap={keyMap}
       handlers={useMemo(
         () => ({
+          REQUEST_TO_SPEAK: () => {
+            modalConfirm("Would you like to ask to speak?", () => {
+                wsend({ op: "ask_to_speak", d: {} });
+            });
+          },
           MUTE: () => {
             const { muted, setMute } = useMuteStore.getState();
             wsend({
@@ -27,6 +35,10 @@ export const KeybindListener: React.FC<KeybindListenerProps> = ({}) => {
               d: { value: !muted },
             });
             setMute(!muted);
+          },
+          INVITE: () => {
+            wsend({ op: "fetch_invite_list", d: { cursor: 0} });
+            history.push("/invite");
           },
           PTT: (e) => {
             if (!e) return;

--- a/kofta/src/app/components/VoiceSettings.tsx
+++ b/kofta/src/app/components/VoiceSettings.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { volumeAtom } from "../shared-atoms";
 import { useMicIdStore } from "../shared-stores";
 import { Button } from "./Button";
-import { MuteKeybind, PTTKeybind, ChatKeybind } from "./keyboard-shortcuts";
+import { MuteKeybind, PTTKeybind, ChatKeybind, InviteKeybind, RequestToSpeakKeybind } from "./keyboard-shortcuts";
 import { VolumeSlider } from "./VolumeSlider";
 import { useTypeSafeTranslation } from "../utils/useTypeSafeTranslation";
 
@@ -72,7 +72,9 @@ export const VoiceSettings: React.FC<VoiceSettingsProps> = () => {
 			</div>
 			<MuteKeybind className={`mb-4`} />
 			<PTTKeybind className={`mb-4`} />
-			<ChatKeybind />
+			<ChatKeybind className={`mb-4`} />
+			<InviteKeybind className={`mb-4`} />
+			<RequestToSpeakKeybind />
 		</>
 	);
 };

--- a/kofta/src/app/components/keyboard-shortcuts/InviteKeybind.tsx
+++ b/kofta/src/app/components/keyboard-shortcuts/InviteKeybind.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { recordKeyCombination } from "react-hotkeys";
+import { useKeyMapStore } from "../../../webrtc/stores/useKeyMapStore";
+import { Button } from "../Button";
+
+interface InviteKeybindProps {
+  className?: string;
+}
+
+export const InviteKeybind: React.FC<InviteKeybindProps> = ({ className }) => {
+  const [count, setCount] = useState(0);
+  const [active, setActive] = useState(false);
+  const {
+    keyNames: { INVITE },
+    setInviteKeybind,
+  } = useKeyMapStore();
+  useEffect(() => {
+    if (count > 0) {
+      const unsub = recordKeyCombination(({ id }) => {
+        setActive(false);
+        setInviteKeybind(id as string);
+      });
+
+      return () => unsub();
+    }
+  }, [count, setInviteKeybind]);
+
+  return (
+    <div className={`flex items-center ${className}`}>
+      <Button
+        variant="small"
+        onClick={() => {
+          setCount((c) => c + 1);
+          setActive(true);
+        }}
+      >
+        set keybind
+      </Button>
+      <div className={`ml-4`}>
+        invite keybind:{" "}
+        <span className={`font-bold text-lg`}>
+          {active ? "listening" : INVITE}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/kofta/src/app/components/keyboard-shortcuts/RequestToSpeakKeybind.tsx
+++ b/kofta/src/app/components/keyboard-shortcuts/RequestToSpeakKeybind.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { recordKeyCombination } from "react-hotkeys";
+import { useKeyMapStore } from "../../../webrtc/stores/useKeyMapStore";
+import { Button } from "../Button";
+
+interface RequestToSpeakKeybindProps {
+  className?: string;
+}
+
+export const RequestToSpeakKeybind: React.FC<RequestToSpeakKeybindProps> = ({ className }) => {
+  const [count, setCount] = useState(0);
+  const [active, setActive] = useState(false);
+  const {
+    keyNames: { REQUEST_TO_SPEAK },
+    setRequestToSpeakKeybind,
+  } = useKeyMapStore();
+  useEffect(() => {
+    if (count > 0) {
+      const unsub = recordKeyCombination(({ id }) => {
+        setActive(false);
+        setRequestToSpeakKeybind(id as string);
+      });
+
+      return () => unsub();
+    }
+  }, [count, setRequestToSpeakKeybind]);
+
+  return (
+    <div className={`flex items-center ${className}`}>
+      <Button
+        variant="small"
+        onClick={() => {
+          setCount((c) => c + 1);
+          setActive(true);
+        }}
+      >
+        set keybind
+      </Button>
+      <div className={`ml-4`}>
+        request to speak keybind:{" "}
+        <span className={`font-bold text-lg`}>
+          {active ? "listening" : REQUEST_TO_SPEAK}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/kofta/src/app/components/keyboard-shortcuts/index.ts
+++ b/kofta/src/app/components/keyboard-shortcuts/index.ts
@@ -1,3 +1,5 @@
+export { RequestToSpeakKeybind } from './RequestToSpeakKeybind';
+export { InviteKeybind } from './InviteKeybind'
 export { MuteKeybind } from './MuteKeybind'
 export { ChatKeybind } from './ChatKeybind'
 export { PTTKeybind } from './PTTKeybind'

--- a/kofta/src/webrtc/stores/useKeyMapStore.ts
+++ b/kofta/src/webrtc/stores/useKeyMapStore.ts
@@ -2,38 +2,44 @@ import { KeyMap } from "react-hotkeys";
 import create from "zustand";
 import { combine } from "zustand/middleware";
 
+const REQUEST_TO_SPEAK_KEY = "@keybind/invite";
+const INVITE_KEY = "@keybind/invite";
 const MUTE_KEY = "@keybind/mute";
 const CHAT_KEY = "@keybind/chat";
 const PTT_KEY = "@keybind/ptt";
 
-function getMuteKeybind() {
-	let v = "";
-	try {
-		v = localStorage.getItem(MUTE_KEY) || "";
-	} catch {}
+function getRequestToSpeakKeybind() {
+	return getKeybind(REQUEST_TO_SPEAK_KEY, "Control+8")
+}
 
-	return v || "Control+m";
+function getInviteKeybind() {
+	return getKeybind(INVITE_KEY, "Control+7")
+}
+
+function getMuteKeybind() {
+	return getKeybind(MUTE_KEY, "Control+m");
 }
 
 function getChatKeybind() {
-	let v = "";
-	try {
-		v = localStorage.getItem(CHAT_KEY) || "";
-	} catch {}
-
-	return v || "Control+9";
+	return getKeybind(CHAT_KEY, "Control+9");
 }
 
 function getPTTKeybind() {
-	let v = "";
+	return getKeybind(PTT_KEY, "Control+0");
+}
+
+function getKeybind(actionKey: string, defaultKeybind: string) {
+	let v = ""
 	try {
-		v = localStorage.getItem(PTT_KEY) || "";
+		v = localStorage.getItem(actionKey) || "";
 	} catch {}
 
-	return v || "Control+0";
+	return v || defaultKeybind;
 }
 
 const keyMap: KeyMap = {
+	REQUEST_TO_SPEAK: getRequestToSpeakKeybind(),
+	INVITE: getInviteKeybind(),
 	MUTE: getMuteKeybind(),
 	CHAT: getChatKeybind(),
 	PTT: [
@@ -43,6 +49,8 @@ const keyMap: KeyMap = {
 };
 
 const keyNames: KeyMap = {
+	REQUEST_TO_SPEAK: getRequestToSpeakKeybind(),
+	INVITE: getInviteKeybind(),
 	MUTE: getMuteKeybind(),
 	CHAT: getChatKeybind(),
 	PTT: getPTTKeybind(),
@@ -55,6 +63,24 @@ export const useKeyMapStore = create(
 			keyNames,
 		},
 		(set) => ({
+			setRequestToSpeakKeybind: (id: string) => {
+				try {
+					localStorage.setItem(REQUEST_TO_SPEAK_KEY, id);
+				} catch {}
+				set((x) => ({
+					keyMap: { ...x.keyMap, REQUEST_TO_SPEAK: id },
+					keyNames: { ...x.keyNames, REQUEST_TO_SPEAK: id },
+				}));
+			},
+			setInviteKeybind: (id: string) => {
+				try {
+					localStorage.setItem(INVITE_KEY, id);
+				} catch {}
+				set((x) => ({
+					keyMap: { ...x.keyMap, INVITE: id },
+					keyNames: { ...x.keyNames, INVITE: id },
+				}));
+			},
 			setMuteKeybind: (id: string) => {
 				try {
 					localStorage.setItem(MUTE_KEY, id);


### PR DESCRIPTION
Two main things were done in this pull request.

1. Added the following hotkeys:
- Request-to-speak: `Control + 8`
- Invite: `Control + 7`

2. Refactored `useKeyMapStore.ts`: Created a `getKeybind` function to use for repetitive logic in `getMuteKeybind`, `getChatKeybind`, etc...
