### PR TITLE
[KIBBEH] Fixed an issue on RoomCard where the SubText of a card will overlap if there are long enough words

### DIFF
--- a/kibbeh/src/ui/RoomCard.tsx
+++ b/kibbeh/src/ui/RoomCard.tsx
@@ -67,7 +67,7 @@ export const RoomCard: React.FC<RoomCardProps> = ({
           </BubbleText>
         </div>
       </div>
-      <div className="text-primary-300 mt-2">{subtitle}</div>
+      <div className="text-primary-300 mt-2 break-words">{subtitle}</div>
       <div className="space-x-2 mt-4">
         {tags.map((tag, idx) => (
           <Tag key={idx}>{tag}</Tag>


### PR DESCRIPTION
Since the RoomCard is marked as done and still has a bug, I decided to implement this simple fix that will save us a lot of headaches in the future. 

--- 

Now with the fixed repository.

**Note to maintainers: this is a kibbeh change, not a kofta one**