### PR TITLE
Fixed overflow of actionButton on baseOverlay due to no border-radius

### DIFF
--- a/kibbeh/src/ui/BaseOverlay.tsx
+++ b/kibbeh/src/ui/BaseOverlay.tsx
@@ -29,7 +29,11 @@ export const BaseOverlay: React.FC<BaseOverlayProps> = ({
       {actionButton && (
         <button
           className="px-4 bg-primary-700 text-primary-100 outline-none font-bold"
-          style={{ paddingTop: 8, paddingBottom: 12 }}
+          style={{
+            paddingTop: 8,
+            paddingBottom: 12,
+            borderRadius: "0 0 8px 8px",
+          }}
           onClick={onActionButtonClicked}
         >
           {actionButton}


### PR DESCRIPTION
The action button is poking out of it's container due to lack of border radius on the base overlay component.

Before:
![before](https://user-images.githubusercontent.com/9110024/111036537-6b4be580-83fe-11eb-9896-f2b5f2a7c11c.png)

After:
![after](https://user-images.githubusercontent.com/9110024/111036550-7737a780-83fe-11eb-884a-182429d0b367.png)

