### PR TITLE
🧹🧹🧹: extend tailwind config to add rounded-8, remove style props

### DIFF
--- a/kibbeh/src/ui/BaseOverlay.tsx
+++ b/kibbeh/src/ui/BaseOverlay.tsx
@@ -15,8 +15,7 @@ export const BaseOverlay: React.FC<BaseOverlayProps> = ({
 }) => {
   return (
     <div
-      style={{ borderRadius: "8px" }}
-      className="flex flex-col w-full bg-primary-800 border border-primary-700"
+      className="flex flex-col w-full rounded-8 bg-primary-800 border border-primary-700"
     >
       {title && (
         <div className="px-4 py-3 border-b border-primary-600 flex items-center">

--- a/kibbeh/src/ui/Search/SearchOverlay.tsx
+++ b/kibbeh/src/ui/Search/SearchOverlay.tsx
@@ -11,8 +11,7 @@ export const SearchOverlay: React.FC<SearchOverlayProps> = ({
 }) => {
   return (
     <div
-      style={{ borderRadius: "8px" }}
-      className={`w-full px-2 pt-7 pb-5 bg-primary-800 border border-primary-700 ${className}`}
+      className={`w-full rounded-8 px-2 pt-7 pb-5 bg-primary-800 border border-primary-700 ${className}`}
     >
       {children}
     </div>

--- a/kibbeh/src/ui/UserSummaryCard.tsx
+++ b/kibbeh/src/ui/UserSummaryCard.tsx
@@ -70,8 +70,7 @@ export const UserSummaryCard: React.FC<UserSummaryCardProps> = ({
 }) => {
   return (
     <div
-      className="flex-col bg-primary-800 p-4 w-full"
-      style={{ borderRadius: "8px" }}
+      className="flex-col rounded-8 bg-primary-800 p-4 w-full"
     >
       <div>
         <SingleUser size="default" isOnline={isOnline} src={avatar} />

--- a/kibbeh/tailwind.config.js
+++ b/kibbeh/tailwind.config.js
@@ -42,6 +42,11 @@ module.exports = {
       6: "40px",
       7: "60px",
     },
+    extend: {
+      borderRadius: {
+        '8': '8px'
+      }
+    },
   },
   variants: {
     backgroundColor: ({ after }) => after(["disabled"]),


### PR DESCRIPTION
Extends the tailwindCSS to add `rounded-8` as a valid class. Open to changing the naming convention, but figured we could be explicit with the size.