### PR TITLE
Confirmation Modal when user joins a room while in a room

### DIFF
--- a/kofta/src/app/pages/Home.tsx
+++ b/kofta/src/app/pages/Home.tsx
@@ -10,6 +10,7 @@ import { BottomVoiceControl } from "../components/BottomVoiceControl";
 import { Button } from "../components/Button";
 import { CircleButton } from "../components/CircleButton";
 import { CreateRoomModal } from "../components/CreateRoomModal";
+import { modalConfirm } from "../components/ConfirmModal";
 import { ProfileButton } from "../components/ProfileButton";
 import { RoomCard } from "../components/RoomCard";
 import { Spinner } from "../components/Spinner";
@@ -74,8 +75,16 @@ const Page = ({
           <div className={`mt-4`} key={r.id}>
             <RoomCard
               onClick={() => {
-                wsend({ op: "join_room", d: { roomId: r.id } });
-                history.push("/room/" + r.id);
+                const joinRoom = () => {
+                  wsend({ op: "join_room", d: { roomId: r.id } });
+                  history.push("/room/" + r.id);
+                };
+                currentRoom
+                  ? modalConfirm(
+                      `Leave room '${currentRoom.name}' and join room '${r.name}'?`,
+                      joinRoom
+                    )
+                  : joinRoom();
               }}
               room={r}
               currentRoomId={currentRoom?.id}


### PR DESCRIPTION
When a user is already in a room and tries to join a new room, a confirmation modal appears asking the user to confirm that they would like to leave the room they are currently in and join the room they selected to join. This modal does not appear when the user is not already in a room, adhering to the logic in [#883](https://github.com/benawad/dogehouse/pull/883). 

![PR Dogehouse Modal](https://user-images.githubusercontent.com/51894836/111041725-a6064b80-8407-11eb-9223-e828b198f361.gif)

