### PR TITLE
Fixing typo in Finnish translation

### DIFF
--- a/kofta/public/locales/fi/translation.json
+++ b/kofta/public/locales/fi/translation.json
@@ -12,7 +12,7 @@
     "edit": "muokkaa",
     "delete": "poista",
     "joinRoom": "liity huoneeseen",
-    "copyLink": "kopio linkki",
+    "copyLink": "kopioi linkki",
     "copied": "kopioitu",
     "formattedIntlDate": "{{date, intlDate}}",
     "formattedIntlTime": "{{time, intlTime}}"


### PR DESCRIPTION
Changing "kopio linkki" to "kopioi linkki"