### PR TITLE
Fixes #443: Show spinner while fetching follower list

### DIFF
--- a/kofta/src/app/atoms.ts
+++ b/kofta/src/app/atoms.ts
@@ -4,49 +4,51 @@ import { Room, BaseUser, UserWithFollowInfo } from "./types";
 import { useMeQuery } from "./utils/useMeQuery";
 
 const createSetter = <T>(a: WritableAtom<T, any>) =>
-	atom(null, (get, set, fn: (x: T) => T) => {
-		set(a, typeof fn === "function" ? fn(get(a)) : fn);
-	});
+  atom(null, (get, set, fn: (x: T) => T) => {
+    set(a, typeof fn === "function" ? fn(get(a)) : fn);
+  });
 
 export const voiceBrowserStatusAtom = atom(-1);
 export const setVoiceBrowserStatusAtom = createSetter(voiceBrowserStatusAtom);
 
 export const inviteListAtom = atom<{
-	users: BaseUser[];
-	nextCursor: number | null;
+  users: BaseUser[];
+  nextCursor: number | null;
 }>({ users: [], nextCursor: null });
 
 export const setInviteListAtom = createSetter(inviteListAtom);
 
 export const followingOnlineAtom = atom<{
-	users: UserWithFollowInfo[];
-	nextCursor: number | null;
+  users: UserWithFollowInfo[];
+  nextCursor: number | null;
 }>({ users: [], nextCursor: null });
 
 export const userSearchAtom = atom<{
-	loading: boolean;
-	users: BaseUser[];
-	nextCursor: number | null;
+  loading: boolean;
+  users: BaseUser[];
+  nextCursor: number | null;
 }>({ users: [], loading: false, nextCursor: null });
 
 export const setFollowingOnlineAtom = createSetter(followingOnlineAtom);
 export const followerMapAtom = atom<
-	Record<
-		string,
-		{
-			users: UserWithFollowInfo[];
-			nextCursor: number | null;
-		}
-	>
+  Record<
+    string,
+    {
+      users: UserWithFollowInfo[];
+      nextCursor: number | null;
+      loading: boolean;
+    }
+  >
 >({});
 export const followingMapAtom = atom<
-	Record<
-		string,
-		{
-			users: UserWithFollowInfo[];
-			nextCursor: number | null;
-		}
-	>
+  Record<
+    string,
+    {
+      users: UserWithFollowInfo[];
+      nextCursor: number | null;
+      loading: boolean;
+    }
+  >
 >({});
 
 export const setFollowingMapAtom = createSetter(followingMapAtom);
@@ -54,46 +56,46 @@ export const setFollowingMapAtom = createSetter(followingMapAtom);
 export const setFollowerMapAtom = createSetter(followerMapAtom);
 
 export const publicRoomsAtom = atom<{
-	publicRooms: Room[];
-	nextCursor: number | null;
+  publicRooms: Room[];
+  nextCursor: number | null;
 }>({ publicRooms: [], nextCursor: null });
 
 export const setPublicRoomsAtom = createSetter(publicRoomsAtom);
 
 export const useCurrentRoomInfo = () => {
-	const { currentRoom: room } = useCurrentRoomStore();
-	const { me } = useMeQuery();
+  const { currentRoom: room } = useCurrentRoomStore();
+  const { me } = useMeQuery();
 
-	if (!room || !me) {
-		return {
-			isMod: false,
-			isCreator: false,
-			isSpeaker: false,
-			canSpeak: false,
-		};
-	}
+  if (!room || !me) {
+    return {
+      isMod: false,
+      isCreator: false,
+      isSpeaker: false,
+      canSpeak: false,
+    };
+  }
 
-	let isMod = false;
-	let isSpeaker = false;
+  let isMod = false;
+  let isSpeaker = false;
 
-	for (const u of room.users) {
-		if (u.id === me.id) {
-			if (u.roomPermissions?.isSpeaker) {
-				isSpeaker = true;
-			}
-			if (u.roomPermissions?.isMod) {
-				isMod = true;
-			}
-			break;
-		}
-	}
+  for (const u of room.users) {
+    if (u.id === me.id) {
+      if (u.roomPermissions?.isSpeaker) {
+        isSpeaker = true;
+      }
+      if (u.roomPermissions?.isMod) {
+        isMod = true;
+      }
+      break;
+    }
+  }
 
-	const isCreator = me.id === room.creatorId;
+  const isCreator = me.id === room.creatorId;
 
-	return {
-		isCreator,
-		isMod,
-		isSpeaker,
-		canSpeak: isCreator || isSpeaker,
-	};
+  return {
+    isCreator,
+    isMod,
+    isSpeaker,
+    canSpeak: isCreator || isSpeaker,
+  };
 };

--- a/kofta/src/app/pages/FollowListPage.tsx
+++ b/kofta/src/app/pages/FollowListPage.tsx
@@ -1,11 +1,12 @@
 import { useAtom } from "jotai";
-import React from "react";
+import React, { useEffect } from "react";
 import { useTypeSafeTranslation } from "../utils/useTypeSafeTranslation";
 import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
 import { wsend } from "../../createWebsocket";
 import { useCurrentRoomStore } from "../../webrtc/stores/useCurrentRoomStore";
 import { followerMapAtom, followingMapAtom } from "../atoms";
 import { Avatar } from "../components/Avatar";
+import { Spinner } from "../components/Spinner";
 import { Backbar } from "../components/Backbar";
 import { BodyWrapper } from "../components/BodyWrapper";
 import { Button } from "../components/Button";
@@ -16,102 +17,129 @@ import { useMeQuery } from "../utils/useMeQuery";
 interface FollowListPageProps {}
 
 export const FollowListPage: React.FC<FollowListPageProps> = () => {
-	const { pathname } = useLocation();
-	const {
-		params: { userId },
-	} = useRouteMatch<{ userId: string }>();
-	const [followerMap, setFollowerMap] = useAtom(followerMapAtom);
-	const [followingMap, setFollowingMap] = useAtom(followingMapAtom);
-	const { me } = useMeQuery();
-	const { setCurrentRoom } = useCurrentRoomStore();
-	const history = useHistory();
-	const { t } = useTypeSafeTranslation();
+  const { pathname } = useLocation();
+  const {
+    params: { userId },
+  } = useRouteMatch<{ userId: string }>();
+  const [followerMap, setFollowerMap] = useAtom(followerMapAtom);
+  const [followingMap, setFollowingMap] = useAtom(followingMapAtom);
+  const { me } = useMeQuery();
+  const { setCurrentRoom } = useCurrentRoomStore();
+  const history = useHistory();
+  const { t } = useTypeSafeTranslation();
 
-	const isFollowing = pathname.startsWith("/following");
+  const isFollowing = pathname.startsWith("/following");
 
-	const users = isFollowing
-		? followingMap[userId]?.users || []
-		: followerMap[userId]?.users || [];
+  useEffect(() => {
+    const fn = isFollowing ? setFollowingMap : setFollowerMap;
+    fn((m) => ({
+      ...m,
+      [userId]: {
+        ...m[userId],
+        loading: true,
+      },
+    }));
+  }, []);
 
-	const nextCursor = isFollowing
-		? followingMap[userId]?.nextCursor
-		: followerMap[userId]?.nextCursor;
+  const users = isFollowing
+    ? followingMap[userId]?.users || []
+    : followerMap[userId]?.users || [];
 
-	return (
-		<Wrapper>
-			<Backbar actuallyGoBack />
-			<BodyWrapper>
-				{!users.length ? <div>{t("common.noUsersFound")}</div> : null}
-				{users.map((profile) => (
-					<div
-						className={`border-b border-solid border-simple-gray-3c flex py-4 px-2 items-center`}
-						key={profile.id}
-					>
-						<button onClick={() => history.push(`/user`, profile)}>
-							<Avatar src={profile.avatarUrl} />
-						</button>
-						<button
-							onClick={() => history.push(`/user`, profile)}
-							className={`ml-8`}
-						>
-							<div className={`text-lg`}>{profile.displayName}</div>
-							<div style={{ color: "" }}>@{profile.username}</div>
-						</button>
-						{me?.id === profile.id ||
-						profile.youAreFollowing === undefined ||
-						profile.youAreFollowing === null ? null : (
-							<div className={`ml-auto`}>
-								<Button
-									onClick={() => {
-										wsend({
-											op: "follow",
-											d: {
-												userId: profile.id,
-												value: !profile.youAreFollowing,
-											},
-										});
-										onFollowUpdater(setCurrentRoom, me, profile);
-										const fn = isFollowing ? setFollowingMap : setFollowerMap;
-										fn((m) => ({
-											...m,
-											[userId]: {
-												users: m[userId].users.map((u) => {
-													if (profile.id === u.id) {
-														return {
-															...u,
-															youAreFollowing: !profile.youAreFollowing,
-														};
-													}
-													return u;
-												}),
-												nextCursor: m[userId].nextCursor,
-											},
-										}));
-									}}
-									variant="small"
-								>
-									{profile.youAreFollowing ? "following" : "follow"}
-								</Button>
-							</div>
-						)}
-					</div>
-				))}
-				{nextCursor ? (
-					<div className={`flex justify-center my-10`}>
-						<Button
-							variant="small"
-							onClick={() =>
-								wsend({
-									op: `fetch_follow_list`,
-									d: { isFollowing, userId, cursor: nextCursor },
-								})
-							}
-						>
-							{t("common.loadMore")}
-						</Button>
-					</div>
-				) : null}
-			</BodyWrapper>
-		</Wrapper>
-	);
+  const nextCursor = isFollowing
+    ? followingMap[userId]?.nextCursor
+    : followerMap[userId]?.nextCursor;
+
+  const loading = isFollowing
+    ? followingMap[userId]?.loading
+    : followerMap[userId]?.loading;
+
+  if (loading) {
+    return (
+      <Wrapper>
+        <Backbar actuallyGoBack />
+        <BodyWrapper>
+          <Spinner centered />
+        </BodyWrapper>
+      </Wrapper>
+    );
+  }
+
+  return (
+    <Wrapper>
+      <Backbar actuallyGoBack />
+      <BodyWrapper>
+        {!users.length ? <div>{t("common.noUsersFound")}</div> : null}
+        {users.map((profile) => (
+          <div
+            className={`border-b border-solid border-simple-gray-3c flex py-4 px-2 items-center`}
+            key={profile.id}
+          >
+            <button onClick={() => history.push(`/user`, profile)}>
+              <Avatar src={profile.avatarUrl} />
+            </button>
+            <button
+              onClick={() => history.push(`/user`, profile)}
+              className={`ml-8`}
+            >
+              <div className={`text-lg`}>{profile.displayName}</div>
+              <div style={{ color: "" }}>@{profile.username}</div>
+            </button>
+            {me?.id === profile.id ||
+            profile.youAreFollowing === undefined ||
+            profile.youAreFollowing === null ? null : (
+              <div className={`ml-auto`}>
+                <Button
+                  onClick={() => {
+                    wsend({
+                      op: "follow",
+                      d: {
+                        userId: profile.id,
+                        value: !profile.youAreFollowing,
+                      },
+                    });
+                    onFollowUpdater(setCurrentRoom, me, profile);
+                    const fn = isFollowing ? setFollowingMap : setFollowerMap;
+                    fn((m) => ({
+                      ...m,
+                      [userId]: {
+                        users: m[userId].users.map((u) => {
+                          if (profile.id === u.id) {
+                            return {
+                              ...u,
+                              youAreFollowing: !profile.youAreFollowing,
+                            };
+                          }
+                          return u;
+                        }),
+                        nextCursor: m[userId].nextCursor,
+                        loading: false,
+                      },
+                    }));
+                  }}
+                  variant="small"
+                >
+                  {profile.youAreFollowing ? "following" : "follow"}
+                </Button>
+              </div>
+            )}
+          </div>
+        ))}
+        {nextCursor ? (
+          <div className={`flex justify-center my-10`}>
+            <Button
+              variant="small"
+              onClick={() =>
+                wsend({
+                  op: `fetch_follow_list`,
+                  d: { isFollowing, userId, cursor: nextCursor },
+                })
+              }
+            >
+              {t("common.loadMore")}
+            </Button>
+          </div>
+        ) : null}
+      </BodyWrapper>
+    </Wrapper>
+  );
 };

--- a/kofta/src/app/useMainWsHandler.ts
+++ b/kofta/src/app/useMainWsHandler.ts
@@ -150,6 +150,7 @@ export const useMainWsHandler = () => {
           [userId]: {
             users: initial ? users : [...m[userId].users, ...users],
             nextCursor,
+            loading: false,
           },
         }));
       },


### PR DESCRIPTION
Adds a loading state value to the follower atoms, and will show the spinner in the list while they are fetching.

Also noticing there are some pretty big diffs because of the white space formatting done by Prettier 😬, is this okay? 

You can test this by throttling your network speed, then opening clicking the "X followers" or "X following" in the user's profile modal. You should see a spinner instead of "no users found".