### PR TITLE
Fixing Finnish Translations

### DIFF
--- a/kofta/public/locales/fi/translation.json
+++ b/kofta/public/locales/fi/translation.json
@@ -12,7 +12,7 @@
     "edit": "muokkaa",
     "delete": "poista",
     "joinRoom": "liity huoneeseen",
-    "copyLink": "kopio linkki",
+    "copyLink": "kopioi linkki",
     "copied": "kopioitu",
     "formattedIntlDate": "{{date, intlDate}}",
     "formattedIntlTime": "{{time, intlTime}}"


### PR DESCRIPTION
Fixing a typo in the Finnish translations (kofta/public/locales/fi/translation.json)
"kopio linkki" -> "kopioi linkki"