### PR TITLE
Fix RoomSearchResult story props mismatch

### DIFF
--- a/kibbeh/src/stories/Search/SearchResult/RoomSearchResult.story.tsx
+++ b/kibbeh/src/stories/Search/SearchResult/RoomSearchResult.story.tsx
@@ -13,8 +13,8 @@ export default {
 
 const room = {
   displayName: "The developer’s hangout",
-  joinedUsers: ["Terry Owen", "Grace Abraham", "Ben Awad"],
-  onlineCount: 355,
+  userCount: 355,
+  hosts: ["Terry Owen", "Grace Abraham"]
 };
 
 export const Main: Story<RoomSearchResultProps> = ({ ...props }) => (


### PR DESCRIPTION
RoomSearchResult story props does not match the UI component's props, making it crash inside story book