### PR TITLE
Update German Translation

### DIFF
--- a/kofta/public/locales/de/translation.json
+++ b/kofta/public/locales/de/translation.json
@@ -25,7 +25,7 @@
 	"footer": {
 		"_comment": "Main Footer UI Internationalization Strings",
 		"link_1": "Ursprungsgeschichte",
-		"link_2": "Onenigheid",
+		"link_2": "Discord",
 		"link_3": "Problem melden"
 	},
 	"pages": {


### PR DESCRIPTION
Dutch was used and Discord is supposed to be used as a noun.