### PR TITLE
Updated German Translation

### DIFF
--- a/kofta/public/locales/de/translation.json
+++ b/kofta/public/locales/de/translation.json
@@ -36,7 +36,7 @@
 		"followingOnlineList": {
 			"listHeader": "Benutzer denen du folgst, die nicht in einem privaten Raum sind.",
 			"currentRoom": "Zurzeit in:",
-			"startPrivateRoom": "Einen privaten Raum mit diesem Benutzer starten"
+			"startPrivateRoom": "Starten Sie mit ihnen ein privates Raum"
 		},
 		"followList": {},
 		"home": {


### PR DESCRIPTION
It no longer says starting a room with a user. Now it correlates with the English translation of starting a room with "them".