### PR TITLE
Kousa: Roomblock error hotfix

### DIFF
--- a/kousa/lib/beef/access/rooms.ex
+++ b/kousa/lib/beef/access/rooms.ex
@@ -65,7 +65,7 @@ defmodule Beef.Access.Rooms do
 
     items =
       from(r in Room,
-        left_join: rb in Beef.RoomBlock,
+        left_join: rb in Beef.Schemas.RoomBlock,
         on: rb.roomId == r.id and rb.userId == ^user_id,
         left_join: ub in UserBlock,
         on: ub.userIdBlocked == ^user_id,


### PR DESCRIPTION
fixes a DB query that someone built that doesn't conform to HHB refactoring