### PR TITLE
Add 'noopener' rel attribute to links in chats

### DIFF
--- a/kofta/src/app/modules/room-chat/RoomChatList.tsx
+++ b/kofta/src/app/modules/room-chat/RoomChatList.tsx
@@ -150,7 +150,7 @@ export const RoomChatList: React.FC<ChatListProps> = ({}) => {
 												return (
 													<a
 														target="_blank"
-														rel="noreferrer"
+														rel="noreferrer noopener"
 														href={v}
 														className={`flex-1 hover:underline text-blue-500`}
 														key={i}


### PR DESCRIPTION
We should add `noopener` rel attribute (in addition to `noreferrer`) to every `<a>` in room chat, in order to prevent malicious websites from controlling us in client side.