### PR TITLE
Add room time elapsed with moon travel status

### DIFF
--- a/kofta/src/app/components/Backbar.tsx
+++ b/kofta/src/app/components/Backbar.tsx
@@ -13,7 +13,7 @@ export const Backbar: React.FC<BackbarProps> = ({
 }) => {
   const history = useHistory();
   return (
-    <div className={`sticky top-0 z-10 flex py-4 mb-12 border-b border-simple-gray-80 bg-simple-gray-26 h-20`}>
+    <div className={`sticky top-0 z-10 flex py-3 mb-12 border-b border-simple-gray-80 bg-simple-gray-26 h-20`}>
       {actuallyGoBack ? (
         <button
           className={`hover:bg-blue-700 px-2`}

--- a/kofta/src/app/components/RoomCard.tsx
+++ b/kofta/src/app/components/RoomCard.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useRef } from "react";
 import { Codicon } from "../svgs/Codicon";
 import { CurrentRoom, Room } from "../types";
 import { useMeQuery } from "../utils/useMeQuery";
+import { useTimeElapsed } from "../utils/timeElapsed";
 
 interface RoomProps {
 	active?: boolean;
@@ -17,6 +18,8 @@ export const RoomCard: React.FC<RoomProps> = ({
 	currentRoomId,
 }) => {
 	const { me } = useMeQuery();
+	const roomRef = useRef(room);
+	const { rocketIcon } = useTimeElapsed(roomRef);
 
 	let n = room.numPeopleInside;
 	const previewNodes = [];
@@ -64,6 +67,7 @@ export const RoomCard: React.FC<RoomProps> = ({
 						{room.name?.slice(0, 100)}
 					</div>
 					<div className={`flex items-center`}>
+						{rocketIcon} &nbsp;
 						<Codicon name="person" /> {n}
 					</div>
 				</div>

--- a/kofta/src/app/components/RoomCard.tsx
+++ b/kofta/src/app/components/RoomCard.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useMemo } from "react";
 import { Codicon } from "../svgs/Codicon";
 import { CurrentRoom, Room } from "../types";
 import { useMeQuery } from "../utils/useMeQuery";
@@ -18,8 +18,8 @@ export const RoomCard: React.FC<RoomProps> = ({
 	currentRoomId,
 }) => {
 	const { me } = useMeQuery();
-	const roomRef = useRef(room);
-	const { rocketIcon } = useTimeElapsed(roomRef);
+	const insertedAtDate = useMemo(() => new Date(room.inserted_at), [room.inserted_at]);
+	const { rocketIcon } = useTimeElapsed(insertedAtDate);
 
 	let n = room.numPeopleInside;
 	const previewNodes = [];

--- a/kofta/src/app/pages/RoomPage.tsx
+++ b/kofta/src/app/pages/RoomPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { Redirect, useRouteMatch } from "react-router-dom";
 import { wsend } from "../../createWebsocket";
 import { useCurrentRoomStore } from "../../webrtc/stores/useCurrentRoomStore";
@@ -18,6 +18,7 @@ import { useShouldFullscreenChat } from "../modules/room-chat/useShouldFullscree
 import { Codicon } from "../svgs/Codicon";
 import { BaseUser } from "../types";
 import { isUuid } from "../utils/isUuid";
+import { useTimeElapsed } from "../utils/timeElapsed";
 import { useMeQuery } from "../utils/useMeQuery";
 import { useTypeSafeTranslation } from "../utils/useTypeSafeTranslation";
 
@@ -29,6 +30,8 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
 	} = useRouteMatch<{ id: string }>();
 	const [userProfileId, setUserProfileId] = useState("");
 	const { currentRoom: room } = useCurrentRoomStore();
+	const roomRef = useRef(room);
+	const { timeElapsed, rocketIcon, rocketStatus } = useTimeElapsed(roomRef);
 	const { muted } = useMuteStore();
 	const { me } = useMeQuery();
 	const {
@@ -61,6 +64,8 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
 		);
 	}
 
+	roomRef.current = room;
+
 	const profile = room.users.find((x) => x.id === userProfileId);
 
 	const speakers: BaseUser[] = [];
@@ -91,13 +96,21 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
 			/>
 			{fullscreenChatOpen ? null : (
 				<Backbar>
-					<button
-						disabled={!iAmCreator}
-						onClick={() => setShowCreateRoomModal(true)}
-						className={`font-xl truncate flex-1 text-center flex items-center justify-center text-2xl`}
-					>
-						<span className={"px-2 truncate"}>{room.name}</span>
-					</button>
+					<div className={`flex flex-1 flex-col items-center`}>
+						<button
+							disabled={!iAmCreator}
+							onClick={() => setShowCreateRoomModal(true)}
+							className={`font-xl truncate flex-1 text-center flex items-center justify-center text-2xl`}
+						>
+							<span className={"px-2 truncate"}>{room.name}</span>
+						</button>
+						{rocketStatus && (
+							<div className={`flex items-center text-sm`}>
+								{rocketIcon} {rocketStatus} &nbsp;
+								<span className="opacity-50">({timeElapsed})</span>
+							</div>
+						)}
+					</div>
 					<ProfileButton />
 				</Backbar>
 			)}

--- a/kofta/src/app/pages/RoomPage.tsx
+++ b/kofta/src/app/pages/RoomPage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { Redirect, useRouteMatch } from "react-router-dom";
 import { wsend } from "../../createWebsocket";
 import { useCurrentRoomStore } from "../../webrtc/stores/useCurrentRoomStore";
@@ -30,8 +30,8 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
 	} = useRouteMatch<{ id: string }>();
 	const [userProfileId, setUserProfileId] = useState("");
 	const { currentRoom: room } = useCurrentRoomStore();
-	const roomRef = useRef(room);
-	const { timeElapsed, rocketIcon, rocketStatus } = useTimeElapsed(roomRef);
+	const insertedAtDate = useMemo(() => room?.inserted_at ? new Date(room.inserted_at) : null, [room?.inserted_at]);
+	const { timeElapsed, rocketIcon, rocketStatus } = useTimeElapsed(insertedAtDate);
 	const { muted } = useMuteStore();
 	const { me } = useMeQuery();
 	const {
@@ -63,8 +63,6 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
 			</Wrapper>
 		);
 	}
-
-	roomRef.current = room;
 
 	const profile = room.users.find((x) => x.id === userProfileId);
 

--- a/kofta/src/app/types.ts
+++ b/kofta/src/app/types.ts
@@ -10,6 +10,7 @@ export type Room = {
 		displayName: string;
 		numFollowers: number;
 	}>;
+	inserted_at: string;
 };
 export type BaseUser = {
 	username: string;

--- a/kofta/src/app/utils/timeElapsed.ts
+++ b/kofta/src/app/utils/timeElapsed.ts
@@ -1,21 +1,19 @@
 import formatDistanceToNowStrict from 'date-fns/formatDistanceToNowStrict';
 import differenceInMinutes from 'date-fns/differenceInMinutes';
-import { RefObject, useEffect, useState } from 'react';
-import { Room } from '../types';
+import { useEffect, useState } from 'react';
 
-export const useTimeElapsed = (roomRef: RefObject<Room>) => {
+export const useTimeElapsed = (startDate: Date | null) => {
     const [timeElapsed, setTimeElapsed] = useState("");
     const [rocketIcon, setRocketIcon] = useState("");
     const [rocketStatus, setRocketStatus] = useState("");
 
-    const updateTime = (roomRef: RefObject<Room>) => {
-        if (!roomRef.current) {
+    const updateTime = (startDate: Date | null) => {
+        if (!startDate) {
             return;
         }
-        const roomDate = new Date(roomRef.current.inserted_at);
-        const timeDiff = differenceInMinutes(new Date(), roomDate);
+        const timeDiff = differenceInMinutes(new Date(), startDate);
 
-        setTimeElapsed(formatDistanceToNowStrict(roomDate, 
+        setTimeElapsed(formatDistanceToNowStrict(startDate, 
             { unit: timeDiff > 120 ? undefined : "minute" }
         ));
 
@@ -25,16 +23,16 @@ export const useTimeElapsed = (roomRef: RefObject<Room>) => {
         } else if (timeDiff < 60) {
             setRocketIcon("🚀");
             setRocketStatus("Taking off");
-        } else if (timeDiff < 120) {
+        } else if (timeDiff < 240) {
             setRocketIcon("🚀✨");
             setRocketStatus("In space");
-        } else if (timeDiff < 240) {
+        } else if (timeDiff < 480) {
             setRocketIcon("🚀🌕");
             setRocketStatus("Approaching moon");
-        } else if (timeDiff < 480) {
+        } else if (timeDiff < 1440) {
             setRocketIcon("🌕🐕");
             setRocketStatus("Lunar doge");
-        } else if (timeDiff < 1440) {
+        } else if (timeDiff < 2880) {
             setRocketIcon("🚀☀️");
             setRocketStatus("Approaching sun");
         } else {
@@ -44,10 +42,10 @@ export const useTimeElapsed = (roomRef: RefObject<Room>) => {
     }
 
     useEffect(() => {
-        updateTime(roomRef);
-        const intervalId = setInterval(() => updateTime(roomRef), 10000);
+        updateTime(startDate);
+        const intervalId = setInterval(() => updateTime(startDate), 10000);
         return () => clearInterval(intervalId);
-    }, [roomRef]);
+    }, [startDate]);
 
     return { timeElapsed, rocketIcon, rocketStatus };
 };

--- a/kofta/src/app/utils/timeElapsed.ts
+++ b/kofta/src/app/utils/timeElapsed.ts
@@ -1,0 +1,53 @@
+import formatDistanceToNowStrict from 'date-fns/formatDistanceToNowStrict';
+import differenceInMinutes from 'date-fns/differenceInMinutes';
+import { RefObject, useEffect, useState } from 'react';
+import { Room } from '../types';
+
+export const useTimeElapsed = (roomRef: RefObject<Room>) => {
+    const [timeElapsed, setTimeElapsed] = useState("");
+    const [rocketIcon, setRocketIcon] = useState("");
+    const [rocketStatus, setRocketStatus] = useState("");
+
+    const updateTime = (roomRef: RefObject<Room>) => {
+        if (!roomRef.current) {
+            return;
+        }
+        const roomDate = new Date(roomRef.current.inserted_at);
+        const timeDiff = differenceInMinutes(new Date(), roomDate);
+
+        setTimeElapsed(formatDistanceToNowStrict(roomDate, 
+            { unit: timeDiff > 120 ? undefined : "minute" }
+        ));
+
+        if (timeDiff < 30) {
+            setRocketIcon("⛽️");
+            setRocketStatus("Fueling rocket");
+        } else if (timeDiff < 60) {
+            setRocketIcon("🚀");
+            setRocketStatus("Taking off");
+        } else if (timeDiff < 120) {
+            setRocketIcon("🚀✨");
+            setRocketStatus("In space");
+        } else if (timeDiff < 240) {
+            setRocketIcon("🚀🌕");
+            setRocketStatus("Approaching moon");
+        } else if (timeDiff < 480) {
+            setRocketIcon("🌕🐕");
+            setRocketStatus("Lunar doge");
+        } else if (timeDiff < 1440) {
+            setRocketIcon("🚀☀️");
+            setRocketStatus("Approaching sun");
+        } else {
+            setRocketIcon("☀️🐕");
+            setRocketStatus("Solar doge");
+        }
+    }
+
+    useEffect(() => {
+        updateTime(roomRef);
+        const intervalId = setInterval(() => updateTime(roomRef), 10000);
+        return () => clearInterval(intervalId);
+    }, [roomRef]);
+
+    return { timeElapsed, rocketIcon, rocketStatus };
+};

--- a/kousa/lib/beef/schemas/room.ex
+++ b/kousa/lib/beef/schemas/room.ex
@@ -16,7 +16,7 @@ defmodule Beef.Schemas.Room do
         }
 
   @derive {Poison.Encoder, only: ~w(id name description numPeopleInside isPrivate
-           creatorId peoplePreviewList voiceServerId)a}
+           creatorId peoplePreviewList voiceServerId inserted_at)a}
   @primary_key {:id, :binary_id, []}
   schema "rooms" do
     field(:name, :string)


### PR DESCRIPTION
This PR adds an indication of how long each room has been active for. Rooms have been taking off lately and it would be great to see how close to the moon each room is. So along with the time indicator, this PR adds icons and a "rocket status" as a bonus for keeping a room active for a while.

This should mostly cover #415, but we could potentially take that issue further.

No extra logic is added on the backend for this, its just using the`inserted_at` timestamp.

![image](https://user-images.githubusercontent.com/28285686/111089980-640eff80-8504-11eb-8fe3-af136c79dc7a.png)
![image](https://user-images.githubusercontent.com/28285686/111090072-b94b1100-8504-11eb-9a08-88ad14105d87.png)
