### PR TITLE
Refetch list of rooms w/ refresh button + polling

### DIFF
--- a/kofta/public/locales/en/translation.json
+++ b/kofta/public/locales/en/translation.json
@@ -40,7 +40,8 @@
 		},
 		"followList": {},
 		"home": {
-			"createRoom": "Create Room"
+			"createRoom": "Create Room",
+			"refresh": "Refresh"
 		},
 		"inviteList": {
 			"roomGone": "room gone, go back",

--- a/kofta/src/app/pages/Home.tsx
+++ b/kofta/src/app/pages/Home.tsx
@@ -42,7 +42,7 @@ const Page = ({
   const { t } = useTypeSafeTranslation();
   const history = useHistory();
   const { status } = useSocketStatus();
-  const { isLoading, data } = useQuery<PublicRoomsQuery>(
+  const { isLoading, data, refetch } = useQuery<PublicRoomsQuery>(
     [get_top_public_rooms, cursor],
     () =>
       wsFetch<any>({
@@ -53,6 +53,7 @@ const Page = ({
       staleTime: Infinity,
       enabled: status === "auth-good",
       refetchOnMount: "always",
+      refetchInterval: 10000,
     }
   );
 
@@ -65,11 +66,18 @@ const Page = ({
   }
 
   if (isOnlyPage && data.rooms.length === 0) {
-    return null;
+    return (
+      <Button variant="small" onClick={() => refetch()}>
+        {t("pages.home.refresh")}
+      </Button>
+    );
   }
 
   return (
     <>
+      <Button variant="small" onClick={() => refetch()}>
+        {t("pages.home.refresh")}
+      </Button>
       {data.rooms.map((r) =>
         r.id === currentRoom?.id ? null : (
           <div className={`mt-4`} key={r.id}>

--- a/kofta/src/generated/translationKeys.ts
+++ b/kofta/src/generated/translationKeys.ts
@@ -25,6 +25,7 @@ export type TranslationKeys =
   | "pages.followingOnlineList.currentRoom"
   | "pages.followingOnlineList.startPrivateRoom"
   | "pages.home.createRoom"
+  | "pages.home.refresh"
   | "pages.inviteList.roomGone"
   | "pages.inviteList.shareRoomLink"
   | "pages.inviteList.inviteFollowers"


### PR DESCRIPTION
Currently you have to refresh the entire browser tab to reload the list of rooms. This PR refetches rooms every 10 seconds (only while the site is active in the foreground). It also adds a "Refresh" button on the home page to refetch the list of rooms without refreshing the page.

Resolves #392.

![image](https://user-images.githubusercontent.com/28285686/111101519-78f98c00-8520-11eb-82a7-2ab845debbd7.png)
