### PR TITLE
Change in Dutch Translation

### DIFF
--- a/kofta/public/locales/nl/translation.json
+++ b/kofta/public/locales/nl/translation.json
@@ -86,7 +86,7 @@
 			"editProfile": "bewerk profiel",
 			"followsYou": "volgt jou",
 			"followers": "volgers",
-			"following": "volgt"
+			"following": "volgend"
 		},
 		"voiceSettings": {
 			"header": "Spraakinstellingen",


### PR DESCRIPTION
Changed "volgt" to "volgend".
I think this is a better translation. This is also how Instagram translates it.