### PR TITLE
Fixing typo in Finnish translations

### DIFF
--- a/kofta/public/locales/fi/translation.json
+++ b/kofta/public/locales/fi/translation.json
@@ -74,7 +74,7 @@
     },
     "room": {
       "speakers": "Puhujat",
-      "requestingToSpeak": "Pyydä puheoikeutta",
+      "requestingToSpeak": "Pyytävät puheoikeutta",
       "listeners": "Kuuntelijat"
     },
     "searchUser": {


### PR DESCRIPTION
Fixing another typo in the Finnish Translations  (kofta/public/locales/fi/translation.json)