### PR TITLE
Fixed transalation to portuguese on word audio.

### DIFF
--- a/kofta/public/locales/pt-BR/translation.json
+++ b/kofta/public/locales/pt-BR/translation.json
@@ -59,7 +59,7 @@
       "logout": "sair",
       "probablyLoading": "possívelmente carregando...",
       "voiceSettings": "ir para configurações de voz",
-      "soundSettings": "ir para configurações de audio",
+      "soundSettings": "ir para configurações de áudio",
       "deleteAccount": "excluír conta"
     },
     "notFound": {

--- a/kofta/public/locales/pt-BR/translation.json
+++ b/kofta/public/locales/pt-BR/translation.json
@@ -60,7 +60,7 @@
       "probablyLoading": "possívelmente carregando...",
       "voiceSettings": "ir para configurações de voz",
       "soundSettings": "ir para configurações de áudio",
-      "deleteAccount": "excluír conta"
+      "deleteAccount": "excluir conta"
     },
     "notFound": {
       "whoopsError": "Ops! Essa página se perdeu na conversa.",


### PR DESCRIPTION
On portuguese the word audio have accent: áudio.