### PR TITLE
Add auto-update (windows only)

### DIFF
--- a/baklava/package.json
+++ b/baklava/package.json
@@ -59,6 +59,7 @@
     }
   },
   "dependencies": {
+    "electron-updater": "^4.3.8",
     "iohook": "^0.7.2"
   },
   "iohook": {

--- a/baklava/src/electron.ts
+++ b/baklava/src/electron.ts
@@ -9,6 +9,7 @@ import {
   shell,
 } from "electron";
 import iohook from "iohook";
+import { autoUpdater } from "electron-updater";
 import { RegisterKeybinds } from "./util";
 import { ALLOWED_HOSTS } from "./constants";
 let mainWindow: BrowserWindow;
@@ -93,6 +94,7 @@ if (!instanceLock) {
 } else {
   app.on("ready", () => {
     createWindow();
+    autoUpdater.checkForUpdatesAndNotify();
   });
   app.on("second-instance", (event, argv, workingDirectory) => {
     if (mainWindow) {


### PR DESCRIPTION
This will allow people using the Windows client to automatically receive updates. 
macOS is supported, but requires code-signing. 
I think that in the future, adding some form of UI element to this could help alert people on macOS & Linux that they are using an outdated client. 