### PR TITLE
Make the default title static...

### DIFF
--- a/kofta/src/app/components/MuteTitleUpdater.tsx
+++ b/kofta/src/app/components/MuteTitleUpdater.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { useMuteStore } from "../../webrtc/stores/useMuteStore";
 import { useTypeSafeTranslation } from "../utils/useTypeSafeTranslation";
 import { useCurrentRoomStore } from "../../webrtc/stores/useCurrentRoomStore";
+import i18next from "i18next";
 
 interface MuteTitleUpdaterProps {}
 
@@ -10,11 +11,11 @@ export const MuteTitleUpdater: React.FC<MuteTitleUpdaterProps> = ({}) => {
   const { currentRoom } = useCurrentRoomStore();
   const { t } = useTypeSafeTranslation();
   useEffect(() => {
-    if (muted && currentRoom) {
-      document.title = t("header.mutedTitle");
-    } else {
-      document.title = t("header.title");
-    }
+		if (muted && currentRoom) {
+			document.title = t("header.mutedTitle");
+		} else {
+			document.title = 	i18next.isInitialized ? t("header.title") : "DogeHouse";
+		}
   }, [muted, t, currentRoom]);
   return null;
 };


### PR DESCRIPTION
...then wait to update it after translations load. 
- closes #1044

I figured leaving the muted title one alone because by the time you can mute yourself to see `Muted | DogeHouse` as the title, the languages have already loaded.