### PR TITLE
Fix center on splash screen

### DIFF
--- a/baklava/splash-screen.html
+++ b/baklava/splash-screen.html
@@ -7,6 +7,6 @@
     <title>Loading DogeHouse</title>
 </head>
 <body>
-    <img style="display: flex; justify-content: center; align-items: center;" src="./icons/icon.png" alt="DogeHouse Logo">
+    <img style="position:fixed;top:50%;left:50%;transform:translate(-50%, -50%);" src="./icons/icon.png" alt="DogeHouse Logo">
 </body>
 </html>


### PR DESCRIPTION
The Electron splash screen was off-center, so I've changed it to use transform with a fixed position to center correctly.