### PR TITLE
Electron wrapper - disable dev tools in production

### DIFF
--- a/baklava/src/electron.ts
+++ b/baklava/src/electron.ts
@@ -52,6 +52,8 @@ function createWindow() {
   // systemPreferences.askForMediaAccess("microphone");
   if (!__prod__) {
     mainWindow.webContents.openDevTools();
+  } else {
+    globalShortcut.register("Control+Shift+I", () => {});
   }
   mainWindow.loadURL(
     __prod__ ? `https://dogehouse.tv/` : "http://localhost:3000/"


### PR DESCRIPTION
Disabled dev tools shortcut (Control + Shift + I) when in production.