### PR TITLE
Regression #990 - Link target and rel

### DIFF
--- a/kofta/src/app/components/Footer.tsx
+++ b/kofta/src/app/components/Footer.tsx
@@ -14,14 +14,26 @@ export const Footer: React.FC<FooterProps> = ({ isLogin }) => {
     <div className={`flex text-center flex-wrap align-center justify-center`}>
       <div className={`flex space-x-4 m-auto`}>
         {isLogin ? (
-          <RegularAnchor href="https://www.youtube.com/watch?v=hy-EhJ_tTQo">
+          <RegularAnchor
+            href="https://www.youtube.com/watch?v=hy-EhJ_tTQo"
+            target="_blank"
+            rel="noreferrer"
+          >
             {t("footer.link_1")}
           </RegularAnchor>
         ) : null}
-        <RegularAnchor href="https://discord.gg/wCbKBZF9cV">
+        <RegularAnchor
+          href="https://discord.gg/wCbKBZF9cV"
+          target="_blank"
+          rel="noreferrer"
+        >
           {t("footer.link_2")}
         </RegularAnchor>
-        <RegularAnchor href="https://github.com/benawad/dogehouse/issues">
+        <RegularAnchor
+          href="https://github.com/benawad/dogehouse/issues"
+          target="_blank"
+          rel="noreferrer"
+        >
           {t("footer.link_3")}
         </RegularAnchor>
         {/* cramps footer on mobile @todo think about how to incorporate this without cramping footer and making the footer really tall */}


### PR DESCRIPTION
I accidentally removed the recently added `target="_blank"` and `rel="noreferrer"` when resolving conflicts. This just adds them back.