### PR TITLE
Added new translation key to fix issue #1131

### DIFF
--- a/kofta/public/locales/af/translation.json
+++ b/kofta/public/locales/af/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "moet in die toekoms wees",
         "roomName": "kamer naam",
-        "minLength": "min lengte 2"
+        "minLength": "min lengte 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/al/translation.json
+++ b/kofta/public/locales/al/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "duhet të jetë në të ardhmen",
         "roomName": "emri i dhomës",
-        "minLength": "gjatesia minimale 2"
+        "minLength": "gjatesia minimale 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/am/translation.json
+++ b/kofta/public/locales/am/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "ፍላጎቶች ወደፊት መሆን አለባቸው",
         "roomName": "የክፍል ስም",
-        "minLength": "ደቂቃ ርዝመት 2"
+        "minLength": "ደቂቃ ርዝመት 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/ar/translation.json
+++ b/kofta/public/locales/ar/translation.json
@@ -194,7 +194,8 @@
       "modal": {
         "needsFuture": "يجب أن تكون في المستقبل",
         "roomName": "اسم الغرفة",
-        "minLength": "أقل طول 2"
+        "minLength": "أقل طول 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/az/translation.json
+++ b/kofta/public/locales/az/translation.json
@@ -199,7 +199,8 @@
       "modal": {
         "needsFuture": "needs to be in the future",
         "roomName": "room name",
-        "minLength": "min length 2"
+        "minLength": "min length 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/bg/translation.json
+++ b/kofta/public/locales/bg/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "трябва да е в бъдещето",
         "roomName": "име на стаята",
-        "minLength": "минимално 2 знака"
+        "minLength": "минимално 2 знака",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/bn/translation.json
+++ b/kofta/public/locales/bn/translation.json
@@ -199,7 +199,8 @@
       "modal": {
         "needsFuture": "ভবিষ্যতের জন্য চাই",
         "roomName": "রুমের নাম",
-        "minLength": "মিনিমাম ২ অক্ষরের"
+        "minLength": "মিনিমাম ২ অক্ষরের",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/cs/translation.json
+++ b/kofta/public/locales/cs/translation.json
@@ -199,7 +199,8 @@
       "modal": {
         "needsFuture": "musí být v budoucnosti",
         "roomName": "jméno místnosti",
-        "minLength": "minimálně dva znaky"
+        "minLength": "minimálně dva znaky",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/da/translation.json
+++ b/kofta/public/locales/da/translation.json
@@ -198,7 +198,8 @@
       "modal": {
         "needsFuture": "skal være i fremtiden",
         "roomName": "Rum navn",
-        "minLength": "Minimum længde på 2 tegn"
+        "minLength": "Minimum længde på 2 tegn",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/de/translation.json
+++ b/kofta/public/locales/de/translation.json
@@ -199,7 +199,8 @@
       "modal": {
         "needsFuture": "Zeitpunkt muss in der Zukunft liegen",
         "roomName": "Name des Raums",
-        "minLength": "minimale Länge: 2"
+        "minLength": "minimale Länge: 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/el-GR/translation.json
+++ b/kofta/public/locales/el-GR/translation.json
@@ -198,7 +198,8 @@
       "modal": {
         "needsFuture": "πρέπει να βρίσκεται στο μέλλον",
         "roomName": "όνομα δωματίου",
-        "minLength": "ελάχιστο μήκος 2"
+        "minLength": "ελάχιστο μήκος 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/en-pirate/translation.json
+++ b/kofta/public/locales/en-pirate/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "needs t' be in the future",
         "roomName": "cabin name",
-        "minLength": "min length 2"
+        "minLength": "min length 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/en/translation.json
+++ b/kofta/public/locales/en/translation.json
@@ -210,6 +210,7 @@
       "modal": {
         "needsFuture": "needs to be in the future",
         "roomName": "room name",
+        "roomDescription": "Description",
         "minLength": "min length 2"
       }
     },

--- a/kofta/public/locales/es/translation.json
+++ b/kofta/public/locales/es/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "necesita ser en el futuro",
         "roomName": "nombre de la sala",
-        "minLength": "longitud mínima de 2 caracteres"
+        "minLength": "longitud mínima de 2 caracteres",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/et/translation.json
+++ b/kofta/public/locales/et/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "peab olema tulevikus",
         "roomName": "ruumi nimi",
-        "minLength": "min. pikkus 2"
+        "minLength": "min. pikkus 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/fi/translation.json
+++ b/kofta/public/locales/fi/translation.json
@@ -197,7 +197,8 @@
       "modal": {
         "needsFuture": "täytyy olla tulevaisuudessa",
         "roomName": "huoneen nimi",
-        "minLength": "minimipituus 2"
+        "minLength": "minimipituus 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/fr/translation.json
+++ b/kofta/public/locales/fr/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "doit dans être dans le futur",
         "roomName": "nom de salle",
-        "minLength": "longueur minimum de 2"
+        "minLength": "longueur minimum de 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/he/translation.json
+++ b/kofta/public/locales/he/translation.json
@@ -194,7 +194,8 @@
       "modal": {
         "needsFuture": "חייב להיות בעתיד",
         "roomName": "שם החדר",
-        "minLength": "אורך מינימלי 2"
+        "minLength": "אורך מינימלי 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/hi/translation.json
+++ b/kofta/public/locales/hi/translation.json
@@ -195,7 +195,8 @@
       "modal": {
         "needsFuture": "भविष्य में होना चाहिए",
         "roomName": "रूम का नाम",
-        "minLength": "काम से काम 2"
+        "minLength": "काम से काम 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/hu/translation.json
+++ b/kofta/public/locales/hu/translation.json
@@ -194,7 +194,8 @@
       "modal": {
         "needsFuture": "jövőbeli dátum szükséges",
         "roomName": "szoba neve",
-        "minLength": "legalább 2 karakter hosszú"
+        "minLength": "legalább 2 karakter hosszú",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/id/translation.json
+++ b/kofta/public/locales/id/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "dibutuhkan di masa depan",
         "roomName": "nama ruangan",
-        "minLength": "minimal panjang 2"
+        "minLength": "minimal panjang 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/is/translation.json
+++ b/kofta/public/locales/is/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "þarf að vera í framtíðinni",
         "roomName": "rásarheiti",
-        "minLength": "lágmarkslengd 2"
+        "minLength": "lágmarkslengd 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/it/translation.json
+++ b/kofta/public/locales/it/translation.json
@@ -198,7 +198,8 @@
       "modal": {
         "needsFuture": "deve essere nel futuro",
         "roomName": "nome della stanza",
-        "minLength": "la lunghezza minima è 2"
+        "minLength": "la lunghezza minima è 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/ja/translation.json
+++ b/kofta/public/locales/ja/translation.json
@@ -194,7 +194,8 @@
       "modal": {
         "needsFuture": "将来的に開催される必要がある",
         "roomName": "名前",
-        "minLength": "2文字以上の名前を指定してください"
+        "minLength": "2文字以上の名前を指定してください",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/kr/translation.json
+++ b/kofta/public/locales/kr/translation.json
@@ -195,7 +195,8 @@
       "modal": {
         "needsFuture": "시간을 미래로 설정하세요",
         "roomName": "채팅방 이름",
-        "minLength": "최소 2자"
+        "minLength": "최소 2자",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/lt/translation.json
+++ b/kofta/public/locales/lt/translation.json
@@ -199,7 +199,8 @@
       "modal": {
         "needsFuture": "Turi būti ateityje",
         "roomName": "Kambario pavadinimas",
-        "minLength": "Mažiausias ilgis 2"
+        "minLength": "Mažiausias ilgis 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/nb/translation.json
+++ b/kofta/public/locales/nb/translation.json
@@ -198,7 +198,8 @@
       "modal": {
         "needsFuture": "må være i fremtiden",
         "roomName": "romnavn",
-        "minLength": "minimun lengde er 2 tegn"
+        "minLength": "minimun lengde er 2 tegn",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/ne/translation.json
+++ b/kofta/public/locales/ne/translation.json
@@ -198,7 +198,8 @@
       "modal": {
         "needsFuture": "भविष्यमा हुनुपर्छ",
         "roomName": "रूमको नाम",
-        "minLength": "न्यूनतम लम्बाई २"
+        "minLength": "न्यूनतम लम्बाई २",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/nl/translation.json
+++ b/kofta/public/locales/nl/translation.json
@@ -198,7 +198,8 @@
       "modal": {
         "needsFuture": "Moet in de toekomst zijn",
         "roomName": "Kamer naam",
-        "minLength": "Minimale lengte 2 karakters"
+        "minLength": "Minimale lengte 2 karakters",
+        "roomDescription": "Beschrijving"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/owo/translation.json
+++ b/kofta/public/locales/owo/translation.json
@@ -199,7 +199,8 @@
       "modal": {
         "needsFuture": "needs to be in da futuwe (人◕ω◕)",
         "roomName": "woom name (◠‿◠✿)",
-        "minLength": "<3 min wength 2 ^_^"
+        "minLength": "<3 min wength 2 ^_^",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/pl/translation.json
+++ b/kofta/public/locales/pl/translation.json
@@ -199,7 +199,8 @@
       "modal": {
         "needsFuture": "musi być w przyszłości",
         "roomName": "nazwa pokoju",
-        "minLength": "minimalna długość to 2"
+        "minLength": "minimalna długość to 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/pt-BR/translation.json
+++ b/kofta/public/locales/pt-BR/translation.json
@@ -195,7 +195,8 @@
       "modal": {
         "needsFuture": "precisa estar no futuro",
         "roomName": "nome da sala",
-        "minLength": "tamanho mínimo: 2"
+        "minLength": "tamanho mínimo: 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/pt-PT/translation.json
+++ b/kofta/public/locales/pt-PT/translation.json
@@ -197,7 +197,8 @@
       "modal": {
         "needsFuture": "a data tem de ser posterior",
         "roomName": "nome da sala",
-        "minLength": "mínimo de 2 caracteres"
+        "minLength": "mínimo de 2 caracteres",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/ro/translation.json
+++ b/kofta/public/locales/ro/translation.json
@@ -199,7 +199,8 @@
       "modal": {
         "needsFuture": "Trebuie să fie în viitor",
         "roomName": "Numele camerei",
-        "minLength": "De minim 2 caractere"
+        "minLength": "De minim 2 caractere",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/ru/translation.json
+++ b/kofta/public/locales/ru/translation.json
@@ -197,7 +197,8 @@
       "modal": {
         "needsFuture": "должно начинаца в будущем",
         "roomName": "название комнаты",
-        "minLength": "минимальная длина 2"
+        "minLength": "минимальная длина 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/se/translation.json
+++ b/kofta/public/locales/se/translation.json
@@ -198,7 +198,8 @@
       "modal": {
         "needsFuture": "behöver vara i framtiden",
         "roomName": "rumsnamn",
-        "minLength": "minimum längd 2"
+        "minLength": "minimum längd 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/sk/translation.json
+++ b/kofta/public/locales/sk/translation.json
@@ -198,7 +198,8 @@
       "modal": {
         "needsFuture": "musí byť v budúcnosti",
         "roomName": "názov miestnosti",
-        "minLength": "minimálne 2 znaky"
+        "minLength": "minimálne 2 znaky",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/sr-Latin/translation.json
+++ b/kofta/public/locales/sr-Latin/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "treba da bude u budućnosti",
         "roomName": "naziv sobe",
-        "minLength": "minimalna dužina 2"
+        "minLength": "minimalna dužina 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/sr/translation.json
+++ b/kofta/public/locales/sr/translation.json
@@ -195,7 +195,8 @@
       "modal": {
         "needsFuture": "Треба да буде у будућности",
         "roomName": "Назив собе",
-        "minLength": "Минимална дужина 2"
+        "minLength": "Минимална дужина 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/th/translation.json
+++ b/kofta/public/locales/th/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "จะต้องมีในอนาคต",
         "roomName": "ชื่อห้อง",
-        "minLength": "ขั้นต่ำ 2 ตัวอักษร"
+        "minLength": "ขั้นต่ำ 2 ตัวอักษร",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/tr/translation.json
+++ b/kofta/public/locales/tr/translation.json
@@ -196,7 +196,8 @@
       "modal": {
         "needsFuture": "Tarih gelecek bir zamanda olmalı",
         "roomName": "Oda ismi",
-        "minLength": "Minimum oda ismi uzunluğu 2"
+        "minLength": "Minimum oda ismi uzunluğu 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/uk/translation.json
+++ b/kofta/public/locales/uk/translation.json
@@ -200,7 +200,8 @@
       "modal": {
         "needsFuture": "має бути в майбутньому",
         "roomName": "назва кімнати",
-        "minLength": "має містити від 2 символів"
+        "minLength": "має містити від 2 символів",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/ur/translation.json
+++ b/kofta/public/locales/ur/translation.json
@@ -197,7 +197,8 @@
       "modal": {
         "needsFuture": "مستقبل میں ہونے کی ضرورت ہے",
         "roomName": "کمرے کا نام",
-        "minLength": "منٹ لمبائی 2"
+        "minLength": "منٹ لمبائی 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/zh-CN/translation.json
+++ b/kofta/public/locales/zh-CN/translation.json
@@ -195,7 +195,8 @@
       "modal": {
         "needsFuture": "需要一个在未来的时间",
         "roomName": "聊天室名字",
-        "minLength": "最短长度为2"
+        "minLength": "最短长度为2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/public/locales/zh-TW/translation.json
+++ b/kofta/public/locales/zh-TW/translation.json
@@ -193,7 +193,8 @@
       "modal": {
         "needsFuture": "需要一個在未來的時間",
         "roomName": "房間名稱",
-        "minLength": "最短長度為 2"
+        "minLength": "最短長度為 2",
+        "roomDescription": "Description"
       }
     },
     "roomChat": {

--- a/kofta/src/app/modules/scheduled-rooms/ScheduleRoomModal.tsx
+++ b/kofta/src/app/modules/scheduled-rooms/ScheduleRoomModal.tsx
@@ -131,7 +131,7 @@ export const ScheduleRoomModal: React.FC<CreateRoomModalProps> = ({
                   <div className={`mt-8`}>
                     <InputField
                       textarea
-                      placeholder="description"
+                      placeholder={t("modules.scheduledRooms.modal.roomDescription")}
                       name="description"
                       maxLength={200}
                     />

--- a/kofta/src/generated/translationKeys.ts
+++ b/kofta/src/generated/translationKeys.ts
@@ -135,6 +135,7 @@ export type TranslationKeys =
 	| "modules.scheduledRooms.startRoom"
 	| "modules.scheduledRooms.modal.needsFuture"
 	| "modules.scheduledRooms.modal.roomName"
+	| "modules.scheduledRooms.modal.roomDescription"
 	| "modules.scheduledRooms.modal.minLength"
 	| "modules.roomChat.title"
 	| "modules.roomChat.emotesSoon"


### PR DESCRIPTION
Provided a fix for issue #1131 by adding a new translation key by running `npm run i18`. Also changed value of the placeholder to reference the corresponding translation key.