### PR TITLE
Resolves #290 - Modal keyboard navigation

### DIFF
--- a/kofta/src/app/components/Modal.tsx
+++ b/kofta/src/app/components/Modal.tsx
@@ -25,9 +25,27 @@ export const Modal: React.FC<ReactModal["props"]> = ({
   children,
   ...props
 }) => {
+  const onKeyDown = (event: any) => {
+    // left arrow key
+    if (event.which === 37) {
+      console.log(event.target.nextElementSibling);
+      event.target.previousElementSibling?.focus();
+      // right arrow key
+    } else if (event.which === 39) {
+      event.target.nextElementSibling?.focus();
+    }
+  };
+
   return (
-    <ReactModal shouldCloseOnEsc style={customStyles} {...props}>
-      {children}
+    <ReactModal
+      shouldCloseOnEsc
+      shouldFocusAfterRender
+      style={customStyles}
+      {...props}
+    >
+      <div tabIndex={-1} onKeyDown={onKeyDown}>
+        {children}
+      </div>
     </ReactModal>
   );
 };

--- a/kofta/src/app/components/Modal.tsx
+++ b/kofta/src/app/components/Modal.tsx
@@ -25,11 +25,12 @@ export const Modal: React.FC<ReactModal["props"]> = ({
   children,
   ...props
 }) => {
-  const onKeyDown = (event: any) => {
-    if (event.code === "ArrowLeft") {
-      event.target.previousElementSibling?.focus();
-    } else if (event.code === "ArrowRight") {
-      event.target.nextElementSibling?.focus();
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    const currentActive = document.activeElement;
+    if (event.key === "ArrowLeft") {
+      (currentActive?.previousElementSibling as HTMLElement)?.focus();
+    } else if (event.key === "ArrowRight") {
+      (currentActive?.nextElementSibling as HTMLElement)?.focus();
     }
   };
 

--- a/kofta/src/app/components/Modal.tsx
+++ b/kofta/src/app/components/Modal.tsx
@@ -28,7 +28,6 @@ export const Modal: React.FC<ReactModal["props"]> = ({
   const onKeyDown = (event: any) => {
     // left arrow key
     if (event.which === 37) {
-      console.log(event.target.nextElementSibling);
       event.target.previousElementSibling?.focus();
       // right arrow key
     } else if (event.which === 39) {

--- a/kofta/src/app/components/Modal.tsx
+++ b/kofta/src/app/components/Modal.tsx
@@ -1,3 +1,4 @@
+import { KeyboardEvent } from "electron";
 import React from "react";
 import ReactModal from "react-modal";
 
@@ -26,11 +27,9 @@ export const Modal: React.FC<ReactModal["props"]> = ({
   ...props
 }) => {
   const onKeyDown = (event: any) => {
-    // left arrow key
-    if (event.which === 37) {
+    if (event.code === "ArrowLeft") {
       event.target.previousElementSibling?.focus();
-      // right arrow key
-    } else if (event.which === 39) {
+    } else if (event.code === "ArrowRight") {
       event.target.nextElementSibling?.focus();
     }
   };

--- a/kofta/src/app/components/Modal.tsx
+++ b/kofta/src/app/components/Modal.tsx
@@ -1,4 +1,3 @@
-import { KeyboardEvent } from "electron";
 import React from "react";
 import ReactModal from "react-modal";
 


### PR DESCRIPTION
Sets the  `shouldFocusAfterRender` prop to for the ReactModal component. This will prevent keyboard events from accidentally being fired behind the overlay.

Created an `onKeyDown` event listener which will focus the previous/next sibling on left/right keys. I tried to add this as props to the ReactModal component, but it seems there is an open issue about this prop not working (https://github.com/reactjs/react-modal/issues/184).

This is also related #184. I saw that @nadirabbas was assigned this, but then removed their assignment. Figured I would just take it since you have a lot on your plate already.
