### PR TITLE
fix contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <h3 align="center">  
-  <a href="https://github.com/benawad/dogehouse/blob/staging/CODE_OF_CONDUCT.md">Contribute</a>
+  <a href="https://github.com/benawad/dogehouse/blob/staging/CONTRIBUTING.md">Contribute</a>
   <span> · </span>
   <a href="https://discord.gg/82HzQCJCDg">Community</a>
   <span> · </span>


### PR DESCRIPTION
Currently the `Contribute` links to CODE_OF_CONDUCT.md which doesn't make sense. It should direct the user to `CONTRIBUTING.md` file for starting to contribute.

A quick fix, let me know how does it sound.