### PR TITLE
Fixed a bug where a live room (in Kibbeh) would switch between a live state and a scheduled state.

### DIFF
--- a/kibbeh/src/ui/Feed.tsx
+++ b/kibbeh/src/ui/Feed.tsx
@@ -40,7 +40,7 @@ export const Feed: React.FC<FeedProps> = ({
                 : ""
             }
             scheduledFor={
-              "scheduledFor" in room ? room.scheduledFor : new Date()
+              "scheduledFor" in room ? new Date(room.scheduledFor) : undefined
             }
             listeners={"numPeopleInside" in room ? room.numPeopleInside : 0}
             tags={[]}

--- a/kibbeh/src/ui/RoomCard.tsx
+++ b/kibbeh/src/ui/RoomCard.tsx
@@ -77,7 +77,7 @@ export const RoomCard: React.FC<RoomCardProps> = ({
           </BubbleText>
         </div>
       </div>
-      <div className="text-primary-300 mt-2 break-words">{subtitle}</div>
+      <div className="text-primary-300 mt-2 break-words block">{subtitle}</div>
       <div className="space-x-2 mt-4">
         {tags.map((tag, idx) => (
           <Tag key={idx}>{tag}</Tag>


### PR DESCRIPTION
Before it would "buffer" between these 2 states:
![image](https://user-images.githubusercontent.com/55450464/111540886-624d7200-8778-11eb-96d9-fe57995c6731.png)
![image](https://user-images.githubusercontent.com/55450464/111540894-67122600-8778-11eb-8c64-024a6acbd295.png)

This bug was caused by the original programmer of the Feed Component providing a Date.now() to the RoomCard, when the RoomCard accepted a null value (or a value in the past) for a Room to be considered live.

This PR resolves this bug. 