### PR TITLE
Fixes #1198 - Room name CSS overflow

### DIFF
--- a/kofta/src/app/pages/RoomPage.tsx
+++ b/kofta/src/app/pages/RoomPage.tsx
@@ -107,7 +107,7 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
             <button
               disabled={!iAmCreator}
               onClick={() => setShowCreateRoomModal(true)}
-              className={`text-2xl truncate max-w-lg text-left`}
+              className={`text-2xl truncate max-w-lg text-center px-2`}
             >
               {room.name}
             </button>

--- a/kofta/src/app/pages/RoomPage.tsx
+++ b/kofta/src/app/pages/RoomPage.tsx
@@ -103,13 +103,13 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
       />
       {fullscreenChatOpen ? null : (
         <Backbar>
-          <div className={`flex flex-1 flex-col items-center`}>
+          <div className={`flex flex-col justify-center"`}>
             <button
               disabled={!iAmCreator}
               onClick={() => setShowCreateRoomModal(true)}
-              className={`font-xl truncate flex-1 text-center flex items-center justify-center text-2xl`}
+              className={`text-2xl truncate max-w-lg text-left`}
             >
-              <span className={"px-2 truncate"}>{room.name}</span>
+              {room.name}
             </button>
             {rocketStatus && (
               <div className={`flex items-center text-sm`}>
@@ -118,7 +118,7 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
               </div>
             )}
           </div>
-          <div className="pr-2">
+          <div className="ml-auto pr-2">
             <ProfileButton />
           </div>
         </Backbar>

--- a/kofta/src/app/pages/RoomPage.tsx
+++ b/kofta/src/app/pages/RoomPage.tsx
@@ -103,7 +103,7 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
       />
       {fullscreenChatOpen ? null : (
         <Backbar>
-          <div className={`flex flex-col justify-center"`}>
+          <div className={`flex flex-col justify-center w-full`}>
             <button
               disabled={!iAmCreator}
               onClick={() => setShowCreateRoomModal(true)}
@@ -112,7 +112,7 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
               {room.name}
             </button>
             {rocketStatus && (
-              <div className={`flex items-center text-sm`}>
+              <div className={`text-center text-sm`}>
                 {rocketIcon} {rocketStatus} &nbsp;
                 <span className="opacity-50">({timeElapsed})</span>
               </div>


### PR DESCRIPTION
The room name text will truncate properly now.
Before:
![before](https://camo.githubusercontent.com/2997ec3ba4364e7bd5f8199696139d7c87965f533a391c2879cc65031466ac84/687474703a2f2f672e7265636f726469742e636f2f775378597146337952702e676966)

After:
![aftershot](https://user-images.githubusercontent.com/9464690/111682877-89b24680-882d-11eb-94e2-eb499301a5aa.png)

Resolves #1198 