### PR TITLE
Add preview deployment for Opening/Closing PRs

### DIFF
--- a/.github/workflows/pr_active.yaml
+++ b/.github/workflows/pr_active.yaml
@@ -1,0 +1,73 @@
+name: Preview Build
+on:
+  pull_request:
+    branches:
+      - staging
+      - main
+      - dev
+    paths:
+      - "kofta/**"
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  build:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Calculate env variables
+        run: |
+          PRNUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          echo "PRNUMBER=$PRNUMBER" >> $GITHUB_ENV
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Install dependencies
+        working-directory: ./kofta
+        run: npm install
+
+      - name: Build
+        working-directory: ./kofta
+        run: npm run build
+
+      - name: Prepare deploy
+        working-directory: ./kofta
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+        run: |
+          git clone https://github.com/cloudflare/worker-sites-template
+          mv worker-sites-template/workers-site .
+          cat << EOF > wrangler.toml
+          name = "dogehouse-pr-${{ env.PRNUMBER }}"
+          type = "webpack"
+          account_id = "$CF_ACCOUNT_ID"
+          workers_dev = true
+          route = ""
+          zone_id = "$CF_ZONE_ID"
+
+          [site]
+          bucket = "./build"
+          EOF
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@1.3.0
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          workingDirectory: "kofta"
+
+      - name: Comment on PR
+        uses: unsplash/comment-on-pr@master
+        if: github.event.action == 'opened'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+        with:
+          msg: "Preview version deployed at https://dogehouse-pr-${{ env.PRNUMBER }}.${{ secrets.CF_BASE_URL }}.workers.dev! The preview version will be updated as new commits are added"

--- a/.github/workflows/pr_active.yaml
+++ b/.github/workflows/pr_active.yaml
@@ -6,7 +6,7 @@ on:
       - main
       - dev
     paths:
-      - "kofta/**"
+      - "kofta/app/**"
     types:
       - opened
       - reopened

--- a/.github/workflows/pr_active.yaml
+++ b/.github/workflows/pr_active.yaml
@@ -6,7 +6,7 @@ on:
       - main
       - dev
     paths:
-      - "kofta/app/**"
+      - "kofta/src/**"
     types:
       - opened
       - reopened

--- a/.github/workflows/pr_closed.yaml
+++ b/.github/workflows/pr_closed.yaml
@@ -6,7 +6,7 @@ on:
       - main
       - dev
     paths:
-      - "kofta/**"
+      - "kofta/src/**"
     types:
       - closed
 

--- a/.github/workflows/pr_closed.yaml
+++ b/.github/workflows/pr_closed.yaml
@@ -1,0 +1,27 @@
+name: Delete Preview Build
+on:
+  pull_request:
+    branches:
+      - staging
+      - main
+      - dev
+    paths:
+      - "kofta/**"
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    name: Clean up
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Delete worker
+        run: |
+          curl -H "Authorization: Bearer $CF_API_TOKEN" -X DELETE "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workers/scripts/dogehouse-pr-$PR"
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This builds previews to Cloudflare Workers for PRs and updates them as new commits are added. It also clears the Workers as commits are closed. 

To setup, secrets for Cloudflare and Github need to be setup.
| Key      | Value |
| ----------- | ----------- |
| CF_ACCOUNT_ID | Cloudflare Account ID |
| CF_API_TOKEN | Cloudflare API Token (Use Manage Workers Preset) |
| CF_BASE_URL | Your worker subdomain (the "vladb" part in "vladb.workers.dev") | 
| CF_ZONE_ID | Cloudflare zone ID | 
| GH_BOT_TOKEN | A Github Token (with repo perms) needed for posting link comments | 



