### PR TITLE
Baklava: Fix missing devscripts

### DIFF
--- a/baklava/package.json
+++ b/baklava/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "compile": "tsc",
     "watch": "tsc -w",
-    "dev": "npm run compile && electron ./dist/electron.js",
+    "dev": "npm run compile && node ./dist/dev.js",
+    "start": "npm run compile && electron ./dist/electron.js",
     "build": "npm run compile && electron-builder",
     "build:all": "npm run compile && electron-builder -mwl --win msi",
     "build:mac": "npm run compile && electron-builder --mac",


### PR DESCRIPTION
Not sure why, but the `package.json` I had in #1195 and the scripts I added are not shown in the commit history of the current `staging` branch. This just adds them back so that the hot reload can be used again.