### PR TITLE
Baklava: Add `exe` build & remove `msi` builds

### DIFF
--- a/baklava/package.json
+++ b/baklava/package.json
@@ -9,9 +9,9 @@
     "dev": "npm run compile && node ./dist/dev.js",
     "start": "npm run compile && electron ./dist/electron.js",
     "build": "npm run compile && electron-builder",
-    "build:all": "npm run compile && electron-builder -mwl --win msi",
+    "build:all": "npm run compile && electron-builder -mwl",
     "build:mac": "npm run compile && electron-builder --mac",
-    "build:win": "npm run compile && electron-builder --win msi",
+    "build:win": "npm run compile && electron-builder --win",
     "build:linux": "npm run compile && electron-builder --linux"
   },
   "keywords": [
@@ -51,7 +51,15 @@
     },
     "win": {
       "icon": "icons/icon.png",
-      "target": "msi"
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        }
+      ]
     },
     "linux": {
       "icon": "icons/icon.png",


### PR DESCRIPTION
The `msi` build seems to be the root of the windows build problem. I've replaced it with an `exe` build which also supports the already implemented auto-update. A proof of concept gh actions build can be found on my [testing](https://github.com/TheOtterlord/dogehouse/actions/runs/667431162) branch