### PR TITLE
Revert "fix(kibbeh): renamed package @dogehouse/kebab to @dogehouse/client"

### DIFF
--- a/kibbeh/package.json
+++ b/kibbeh/package.json
@@ -15,7 +15,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@dogehouse/client": "^0.1.2",
+    "@dogehouse/kebab": "^0.1.2",
     "@svgr/webpack": "^5.5.0",
     "date-fns": "^2.19.0",
     "formik": "^2.2.6",


### PR DESCRIPTION
Oh god no, this broke the package. 

@dogehouse/kebab is a yarn workspace while @dogehouse/client is an outdated version of DogeGarden. 

Please revert this ASAP.

(Also, if you want to use @dogehouse/kebab, use yarn [and yarn build kebab first])