### PR TITLE
fix: long room name on navbar #1223

### DIFF
--- a/kofta/src/app/components/Backbar.tsx
+++ b/kofta/src/app/components/Backbar.tsx
@@ -14,7 +14,7 @@ export const Backbar: React.FC<BackbarProps> = ({
   const history = useHistory();
   return (
     <div
-      className={`sticky top-0 z-10 flex py-3 mb-12 border-b border-simple-gray-80 bg-simple-gray-26 h-20`}
+      className={`sticky top-0 z-10 flex items-center py-3 mb-12 border-b border-simple-gray-80 bg-simple-gray-26 h-20`}
     >
       {actuallyGoBack ? (
         <button

--- a/kofta/src/app/pages/RoomPage.tsx
+++ b/kofta/src/app/pages/RoomPage.tsx
@@ -103,7 +103,7 @@ export const RoomPage: React.FC<RoomPageProps> = () => {
       />
       {fullscreenChatOpen ? null : (
         <Backbar>
-          <div className={`flex flex-col justify-center w-full`}>
+          <div className={`flex flex-col justify-center w-9/12`}>
             <button
               disabled={!iAmCreator}
               onClick={() => setShowCreateRoomModal(true)}


### PR DESCRIPTION
Resolves: Dogehouse and Profile Menu are push off screen on mobile devices when a room name is too long. #1223
