### PR TITLE
New Code for Pushing Deployments

### DIFF
--- a/.github/workflows/pr_active.yaml
+++ b/.github/workflows/pr_active.yaml
@@ -1,0 +1,70 @@
+name: Preview Build
+on:
+  pull_request_target:
+    branches:
+      - staging
+      - main
+      - dev
+    paths:
+      - "kofta/src/**"
+    types:
+      - labeled
+
+jobs:
+  build:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe to deploy')
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Install dependencies
+        working-directory: ./kofta
+        run: npm install
+
+      - name: Build
+        working-directory: ./kofta
+        run: npm run build
+
+      - name: Prepare deploy
+        working-directory: ./kofta
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+          PRNUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git clone https://github.com/cloudflare/worker-sites-template
+          mv worker-sites-template/workers-site .
+          cat << EOF > wrangler.toml
+          name = "dogehouse-pr-$PRNUMBER"
+          type = "webpack"
+          account_id = "$CF_ACCOUNT_ID"
+          workers_dev = true
+          route = ""
+          zone_id = "$CF_ZONE_ID"
+          [site]
+          bucket = "./build"
+          EOF
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@1.3.0
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          workingDirectory: "kofta"
+
+      - name: Comment on PR
+        uses: unsplash/comment-on-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          PRNUMBER: ${{ github.event.pull_request.number }}
+        with:
+          msg: "Preview version deployed at https://dogehouse-pr-$PRNUMBER.${{ secrets.CF_BASE_URL }}.workers.dev! The preview version will be updated as new commits are added"

--- a/.github/workflows/pr_closed.yaml
+++ b/.github/workflows/pr_closed.yaml
@@ -1,0 +1,31 @@
+name: Delete Preview Build
+on:
+  pull_request_target:
+    branches:
+      - staging
+      - main
+      - dev
+    paths:
+      - "kofta/src/**"
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    name: Clean up
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe to deploy')
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Delete worker
+        run: |
+          curl -H "Authorization: Bearer $CF_API_TOKEN" -X DELETE "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workers/scripts/dogehouse-pr-$PR"
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Continuation of #1215 
Fixes #1255
Now, to trigger a deploy, a person with write permissions must add a "safe to deploy" label to the PR. 

## More Info
https://securitylab.github.com/research/github-actions-preventing-pwn-requests