### PR TITLE
Made the minimum size of the description box smaller

### DIFF
--- a/kofta/src/app/modules/room-chat/RoomDescription.tsx
+++ b/kofta/src/app/modules/room-chat/RoomDescription.tsx
@@ -3,8 +3,8 @@ import { useCurrentRoomStore } from "../../../webrtc/stores/useCurrentRoomStore"
 import { truncate } from "../../utils/truncate";
 import { useTypeSafeTranslation } from "../../utils/useTypeSafeTranslation";
 
-const MAX_COLLAPSED_CHARACTERS = 100;
-const MAX_COLLAPSED_LINES = 6;
+const MAX_COLLAPSED_CHARACTERS = 60;
+const MAX_COLLAPSED_LINES = 2;
 
 interface RoomDescriptionProps {}
 


### PR DESCRIPTION
Changed the option to make the description box smaller, because it usually blocks the chat and causes the emoji picker to go off-screen. #1222