### PR TITLE
Kousa: Use simpler control flow structures where possible

### DIFF
--- a/kousa/lib/beef/access/rooms.ex
+++ b/kousa/lib/beef/access/rooms.ex
@@ -50,12 +50,10 @@ defmodule Beef.Access.Rooms do
             {:error, "you are blocked from the room"}
 
           true ->
-            cond do
-              UserBlocks.blocked?(room.creatorId, user_id) ->
-                {:error, "the creator of the room blocked you"}
-
-              true ->
-                {:ok, room}
+            if UserBlocks.blocked?(room.creatorId, user_id) do
+              {:error, "the creator of the room blocked you"}
+            else
+              {:ok, room}
             end
         end
     end

--- a/kousa/lib/beef/mutations/users.ex
+++ b/kousa/lib/beef/mutations/users.ex
@@ -109,40 +109,38 @@ defmodule Beef.Mutations.Users do
       )
       |> Repo.one()
 
-    cond do
-      db_user ->
-        if is_nil(db_user.twitterId) do
-          from(u in User,
-            where: u.id == ^db_user.id,
-            update: [
-              set: [
-                twitterId: ^user.twitterId
-              ]
+    if db_user do
+      if is_nil(db_user.twitterId) do
+        from(u in User,
+          where: u.id == ^db_user.id,
+          update: [
+            set: [
+              twitterId: ^user.twitterId
             ]
-          )
-          |> Repo.update_all([])
-        end
+          ]
+        )
+        |> Repo.update_all([])
+      end
 
-        {:find, db_user}
-
-      true ->
-        {:create,
-         Repo.insert!(
-           %User{
-             username: Kousa.Utils.Random.big_ascii_id(),
-             email: if(user.email == "", do: nil, else: user.email),
-             twitterId: user.twitterId,
-             avatarUrl: user.avatarUrl,
-             displayName:
-               if(is_nil(user.displayName) or String.trim(user.displayName) == "",
-                 do: "Novice Doge",
-                 else: user.displayName
-               ),
-             bio: user.bio,
-             hasLoggedIn: true
-           },
-           returning: true
-         )}
+      {:find, db_user}
+    else
+      {:create,
+       Repo.insert!(
+         %User{
+           username: Kousa.Utils.Random.big_ascii_id(),
+           email: if(user.email == "", do: nil, else: user.email),
+           twitterId: user.twitterId,
+           avatarUrl: user.avatarUrl,
+           displayName:
+             if(is_nil(user.displayName) or String.trim(user.displayName) == "",
+               do: "Novice Doge",
+               else: user.displayName
+             ),
+           bio: user.bio,
+           hasLoggedIn: true
+         },
+         returning: true
+       )}
     end
   end
 
@@ -158,42 +156,40 @@ defmodule Beef.Mutations.Users do
       )
       |> Repo.one()
 
-    cond do
-      db_user ->
-        if is_nil(db_user.githubId) do
-          from(u in User,
-            where: u.id == ^db_user.id,
-            update: [
-              set: [
-                githubId: ^githubId,
-                githubAccessToken: ^github_access_token
-              ]
+    if db_user do
+      if is_nil(db_user.githubId) do
+        from(u in User,
+          where: u.id == ^db_user.id,
+          update: [
+            set: [
+              githubId: ^githubId,
+              githubAccessToken: ^github_access_token
             ]
-          )
-          |> Repo.update_all([])
-        end
+          ]
+        )
+        |> Repo.update_all([])
+      end
 
-        {:find, db_user}
-
-      true ->
-        {:create,
-         Repo.insert!(
-           %User{
-             username: Kousa.Utils.Random.big_ascii_id(),
-             githubId: githubId,
-             email: if(user["email"] == "", do: nil, else: user["email"]),
-             githubAccessToken: github_access_token,
-             avatarUrl: user["avatar_url"],
-             displayName:
-               if(is_nil(user["name"]) or String.trim(user["name"]) == "",
-                 do: "Novice Doge",
-                 else: user["name"]
-               ),
-             bio: user["bio"],
-             hasLoggedIn: true
-           },
-           returning: true
-         )}
+      {:find, db_user}
+    else
+      {:create,
+       Repo.insert!(
+         %User{
+           username: Kousa.Utils.Random.big_ascii_id(),
+           githubId: githubId,
+           email: if(user["email"] == "", do: nil, else: user["email"]),
+           githubAccessToken: github_access_token,
+           avatarUrl: user["avatar_url"],
+           displayName:
+             if(is_nil(user["name"]) or String.trim(user["name"]) == "",
+               do: "Novice Doge",
+               else: user["name"]
+             ),
+           bio: user["bio"],
+           hasLoggedIn: true
+         },
+         returning: true
+       )}
     end
   end
 end

--- a/kousa/lib/beef/scheduled_rooms.ex
+++ b/kousa/lib/beef/scheduled_rooms.ex
@@ -46,23 +46,24 @@ defmodule Beef.ScheduledRooms do
           :invalid | %{optional(:__struct__) => none, optional(atom | binary) => any}
         ) :: :ok | {:error, Ecto.Changeset.t()}
   def edit(user_id, id, data) do
-    with {:ok, cleaned_data} <-
-           ScheduledRoom.edit_changeset(%ScheduledRoom{}, data) |> apply_action(:update) do
-      from(sr in ScheduledRoom,
-        where: sr.creatorId == ^user_id and sr.id == ^id,
-        update: [
-          set: [
-            name: ^cleaned_data.name,
-            description: ^cleaned_data.description,
-            scheduledFor: ^cleaned_data.scheduledFor
+    case ScheduledRoom.edit_changeset(%ScheduledRoom{}, data) |> apply_action(:update) do
+      {:ok, cleaned_data} ->
+        from(sr in ScheduledRoom,
+          where: sr.creatorId == ^user_id and sr.id == ^id,
+          update: [
+            set: [
+              name: ^cleaned_data.name,
+              description: ^cleaned_data.description,
+              scheduledFor: ^cleaned_data.scheduledFor
+            ]
           ]
-        ]
-      )
-      |> Repo.update_all([])
+        )
+        |> Repo.update_all([])
 
-      :ok
-    else
-      error -> error
+        :ok
+
+      error ->
+        error
     end
   end
 

--- a/kousa/lib/broth/socket_handler.ex
+++ b/kousa/lib/broth/socket_handler.ex
@@ -119,71 +119,69 @@ defmodule Broth.SocketHandler do
                   y -> y
                 end
 
-              cond do
-                user ->
-                  {:ok, session} =
-                    GenRegistry.lookup_or_start(Onion.UserSession, user_id, [
-                      %Onion.UserSession.State{
-                        user_id: user_id,
-                        username: user.username,
-                        avatar_url: user.avatarUrl,
-                        display_name: user.displayName,
-                        current_room_id: user.currentRoomId,
-                        muted: muted
-                      }
-                    ])
+              if user do
+                {:ok, session} =
+                  GenRegistry.lookup_or_start(Onion.UserSession, user_id, [
+                    %Onion.UserSession.State{
+                      user_id: user_id,
+                      username: user.username,
+                      avatar_url: user.avatarUrl,
+                      display_name: user.displayName,
+                      current_room_id: user.currentRoomId,
+                      muted: muted
+                    }
+                  ])
 
-                  GenServer.call(session, {:set_pid, self()})
+                GenServer.call(session, {:set_pid, self()})
 
-                  if tokens do
-                    GenServer.cast(session, {:new_tokens, tokens})
+                if tokens do
+                  GenServer.cast(session, {:new_tokens, tokens})
+                end
+
+                roomIdFromFrontend = Map.get(json["d"], "currentRoomId", nil)
+
+                currentRoom =
+                  cond do
+                    not is_nil(user.currentRoomId) ->
+                      # @todo this should probably go inside room business logic
+                      room = Rooms.get_room_by_id(user.currentRoomId)
+
+                      {:ok, room_session} =
+                        GenRegistry.lookup_or_start(Onion.RoomSession, user.currentRoomId, [
+                          %{
+                            room_id: user.currentRoomId,
+                            voice_server_id: room.voiceServerId
+                          }
+                        ])
+
+                      GenServer.cast(
+                        room_session,
+                        {:join_room, user, muted}
+                      )
+
+                      if reconnectToVoice == true do
+                        Kousa.Room.join_vc_room(user.id, room)
+                      end
+
+                      room
+
+                    not is_nil(roomIdFromFrontend) ->
+                      case Kousa.Room.join_room(user.id, roomIdFromFrontend) do
+                        %{room: room} -> room
+                        _ -> nil
+                      end
+
+                    true ->
+                      nil
                   end
 
-                  roomIdFromFrontend = Map.get(json["d"], "currentRoomId", nil)
-
-                  currentRoom =
-                    cond do
-                      not is_nil(user.currentRoomId) ->
-                        # @todo this should probably go inside room business logic
-                        room = Rooms.get_room_by_id(user.currentRoomId)
-
-                        {:ok, room_session} =
-                          GenRegistry.lookup_or_start(Onion.RoomSession, user.currentRoomId, [
-                            %{
-                              room_id: user.currentRoomId,
-                              voice_server_id: room.voiceServerId
-                            }
-                          ])
-
-                        GenServer.cast(
-                          room_session,
-                          {:join_room, user, muted}
-                        )
-
-                        if reconnectToVoice == true do
-                          Kousa.Room.join_vc_room(user.id, room)
-                        end
-
-                        room
-
-                      not is_nil(roomIdFromFrontend) ->
-                        case Kousa.Room.join_room(user.id, roomIdFromFrontend) do
-                          %{room: room} -> room
-                          _ -> nil
-                        end
-
-                      true ->
-                        nil
-                    end
-
-                  {:reply,
-                   construct_socket_msg(state.encoding, state.compression, %{
-                     op: "auth-good",
-                     d: %{user: user, currentRoom: currentRoom}
-                   }), %{state | user_id: user_id, awaiting_init: false, platform: platform}}
-
-                true ->
-                  {:reply, {:close, 4001, "invalid_authentication"}, state}
+                {:reply,
+                 construct_socket_msg(state.encoding, state.compression, %{
+                   op: "auth-good",
+                   d: %{user: user, currentRoom: currentRoom}
+                 }), %{state | user_id: user_id, awaiting_init: false, platform: platform}}
+              else
+                {:reply, {:close, 4001, "invalid_authentication"}, state}
               end
           end
 
@@ -570,15 +568,13 @@ defmodule Broth.SocketHandler do
          {:ok, voice_server_id} <-
            RegUtils.lookup_and_call(Onion.RoomSession, room_id, {:get_voice_server_id}) do
       d =
-        cond do
-          String.first(op) == "@" ->
-            Map.merge(data, %{
-              peerId: state.user_id,
-              roomId: room_id
-            })
-
-          true ->
-            data
+        if String.first(op) == "@" do
+          Map.merge(data, %{
+            peerId: state.user_id,
+            roomId: room_id
+          })
+        else
+          data
         end
 
       Onion.VoiceRabbit.send(voice_server_id, %{
@@ -608,18 +604,16 @@ defmodule Broth.SocketHandler do
     {room_id, users} = Beef.Users.get_users_in_current_room(state.user_id)
 
     {muteMap, autoSpeaker, activeSpeakerMap} =
-      cond do
-        not is_nil(room_id) ->
-          case GenRegistry.lookup(Onion.RoomSession, room_id) do
-            {:ok, session} ->
-              GenServer.call(session, {:get_maps})
+      if is_nil(room_id) do
+        {%{}, false, %{}}
+      else
+        case GenRegistry.lookup(Onion.RoomSession, room_id) do
+          {:ok, session} ->
+            GenServer.call(session, {:get_maps})
 
-            _ ->
-              {%{}, false, %{}}
-          end
-
-        true ->
-          {%{}, false, %{}}
+          _ ->
+            {%{}, false, %{}}
+        end
       end
 
     %{

--- a/kousa/lib/kousa/room.ex
+++ b/kousa/lib/kousa/room.ex
@@ -183,6 +183,7 @@ defmodule Kousa.Room do
         case Rooms.replace_room_owner(old_creator_id, new_creator_id) do
           {1, _} ->
             internal_set_speaker(old_creator_id, current_room_id)
+
             Onion.RoomSession.send_cast(
               current_room_id,
               {:send_ws_msg, :vscode,
@@ -345,11 +346,9 @@ defmodule Kousa.Room do
               )
 
               canSpeak =
-                with %{roomPermissions: %{isSpeaker: true}} <- updated_user do
-                  true
-                else
-                  _ ->
-                    false
+                case updated_user do
+                  %{roomPermissions: %{isSpeaker: true}} -> true
+                  _ -> false
                 end
 
               join_vc_room(user_id, room, canSpeak || room.isPrivate)

--- a/kousa/lib/kousa/scheduled_room.ex
+++ b/kousa/lib/kousa/scheduled_room.ex
@@ -4,11 +4,13 @@ defmodule Kousa.ScheduledRoom do
   alias Beef.ScheduledRooms
 
   def create_room_from_scheduled_room(user_id, scheduled_room_id, name, description) do
-    with {:ok, response} <- Kousa.Room.create_room(user_id, name, description, false) do
-      ScheduledRooms.room_started(user_id, scheduled_room_id, response.room.id)
-      {:ok, response}
-    else
-      error -> error
+    case Kousa.Room.create_room(user_id, name, description, false) do
+      {:ok, response} ->
+        ScheduledRooms.room_started(user_id, scheduled_room_id, response.room.id)
+        {:ok, response}
+
+      error ->
+        error
     end
   end
 


### PR DESCRIPTION
This replaces `cond` statements with a single branch and a `true` with a simpler `if` statement and `with` statements with a single statement with a simpler `case`.
This patch also removes a bunch of credo refactoring complaints relating to both of these.

Functionally there's no difference between the variants, but the code is more easily readable this way.