### PR TITLE
Fix link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please read [CONTRIBUTING.md](https://github.com/benawad/dogehouse/blob/staging/
 
 A desktop app built with electron is available for Windows and Mac
 
-Download links are in [the releases section](https://github.com/benawad/dogehouse/releases/tag/latest)
+Download links are in [the releases section](https://github.com/benawad/dogehouse/releases/latest)
 
 Built with electron.
 


### PR DESCRIPTION
The link to the releases section was returning 404. I have updated it to use the correct link.