### PR TITLE
fix(roomcard): hide long display names on roomcard

### DIFF
--- a/kofta/src/app/components/RoomCard.tsx
+++ b/kofta/src/app/components/RoomCard.tsx
@@ -39,7 +39,7 @@ export const RoomCard: React.FC<RoomProps> = ({
     previewNodes.push(
       <div
         key={p.id}
-        className={`text-left text-simple-gray-d9 ${!i ? "mt-1.5" : "mt-0.5"}`}
+        className={`text-left text-simple-gray-d9 overflow-x-hidden ${!i ? "mt-1.5" : "mt-0.5"}`}
       >
         {p.displayName?.slice(0, 50)}
       </div>


### PR DESCRIPTION
fix #1557

Before:
![Screenshot from 2021-03-25 20-49-09](https://user-images.githubusercontent.com/2265262/112541674-9396f500-8dab-11eb-9f70-2d00dbc1b992.png)

After:
![Screenshot from 2021-03-25 20-46-39](https://user-images.githubusercontent.com/2265262/112541596-795d1700-8dab-11eb-803c-fae43e568f97.png)
