### PR TITLE
build(global): fix compiler warnings in kofta

### DIFF
--- a/kofta/src/app/components/OverlaySettings.tsx
+++ b/kofta/src/app/components/OverlaySettings.tsx
@@ -30,7 +30,7 @@ export const OverlaySettings: React.FC<OverlaySettingsProps> = () => {
         if (!isElectron() || isMac) {
             history.push('/me')
         }
-    }, []);
+    }, [history]);
 
     return (
         <>

--- a/kofta/src/app/pages/Home.tsx
+++ b/kofta/src/app/pages/Home.tsx
@@ -65,7 +65,7 @@ const Page = ({
     if (isElectron() && isMac) {
         modalAlert(t("common.requestPermissions"));
     }
-  }, []);
+  }, [t]);
 
   if (isLoading) {
     return <Spinner centered={true} />;

--- a/kofta/src/app/pages/Login.tsx
+++ b/kofta/src/app/pages/Login.tsx
@@ -32,7 +32,7 @@ export const Login: React.FC<LoginProps> = () => {
     if (isElectron() && isMac) {
       modalAlert(t("common.requestPermissions"));
     }
-  }, []);
+  }, [t]);
   return (
     <CenterLayout>
       <Wrapper>

--- a/kofta/src/app/pages/ViewUserPage.tsx
+++ b/kofta/src/app/pages/ViewUserPage.tsx
@@ -8,7 +8,7 @@ import { BodyWrapper } from "../components/BodyWrapper";
 import { Spinner } from "../components/Spinner";
 import { UserProfile } from "../components/UserProfile";
 import { Wrapper } from "../components/Wrapper";
-import { RoomUser, UserWithFollowInfo } from "../types";
+import { RoomUser } from "../types";
 import { useTypeSafeTranslation } from "../utils/useTypeSafeTranslation";
 import { useUserProfileQuery } from "../utils/useUserProfileQuery";
 


### PR DESCRIPTION
We were getting warnings when compiling kofta in these files

Fixes the following warnings when building kofta:
```
src/app/components/OverlaySettings.tsx
  Line 33:8:  React Hook useEffect has a missing dependency: 'history'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

src/app/pages/Home.tsx
  Line 68:6:  React Hook useEffect has a missing dependency: 't'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

src/app/pages/Login.tsx
  Line 35:6:  React Hook useEffect has a missing dependency: 't'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

src/app/pages/ViewUserPage.tsx
  Line 11:20:  'UserWithFollowInfo' is defined but never used  @typescript-eslint/no-unused-vars
```