### PR TITLE
feat(global): Added .devcontainer for an easier local development environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+# Update to pick an Elixir version: 1.9, 1.10, 1.10.4
+ARG VARIANT=latest
+FROM elixir:${VARIANT}
+
+ENV USERNAME=doge
+ENV USER_UID=1000
+ENV USER_GID=$USER_UID
+
+COPY scripts/*.sh /tmp/scripts/
+
+# Create non-root doge user
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && bash /tmp/scripts/user.sh "$USERNAME" "$USER_UID" "$USER_GID" \
+    # Clean up
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /root/.gnupg
+
+# Install Node.js
+ENV NVM_DIR=/home/$USERNAME/.nvm
+ENV NODE_VERSION="lts/*"
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    # Install common packages, non-root user, update yarn and install nvm
+    && bash /tmp/scripts/node.sh "$NVM_DIR" "$NODE_VERSION" "$USERNAME" \
+    # Clean up
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /root/.gnupg
+
+# Cleanup scripts
+RUN rm -rf /tmp/scripts
+
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "Dogehouse",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "workspace",
+    "workspaceFolder": "/workspace",
+    "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "jakebecker.elixir-ls",
+        "bradlc.vscode-tailwindcss"
+    ],
+    "forwardPorts": [
+        80,
+        3000,
+        4001,
+        8080,
+        5432,
+        5672,
+        15672 // rabbit.mq management interface 
+    ],
+    "postCreateCommand": ["bash", ".devcontainer/scripts/environment.sh"],
+    "remoteUser": "doge"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3"
+
+services:
+  workspace:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace:cached
+
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: kousa_repo2 # Initial schema name
+    network_mode: service:workspace
+
+  rabbitmq:
+    image: rabbitmq:management
+    restart: unless-stopped
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq/data
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    network_mode: service:workspace
+
+volumes:
+  postgres-data:
+  rabbitmq-data:

--- a/.devcontainer/scripts/environment.sh
+++ b/.devcontainer/scripts/environment.sh
@@ -1,0 +1,25 @@
+# kousa
+cat >> "/home/$USERNAME/.bashrc" << EOL
+
+# Kousa environment variables 
+export DATABASE_URL=postgres://postgres:postgres@localhost/kousa_repo2
+export BEN_GITHUB_ID=7872329
+export RABBITMQ_URL=amqp://guest:guest@localhost:5672
+export ACCESS_TOKEN_SECRET=
+export REFRESH_TOKEN_SECRET=
+export GITHUB_CLIENT_ID=
+export TWITTER_API_KEY=
+export TWITTER_SECRET_KEY=
+export TWITTER_BEARER_TOKEN=
+export GITHUB_CLIENT_SECRET=
+export SENTRY_DNS=
+export API_URL=http://localhost:4001
+export WEB_URL=http://localhost:3000
+export PORT=4001
+EOL
+
+# shawarma
+echo "WEBRTC_LISTEN_IP=127.0.0.1" > shawarma/.env
+
+# kofta
+cp kofta/.env.example kofta/.env

--- a/.devcontainer/scripts/node.sh
+++ b/.devcontainer/scripts/node.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+USERNAME=${3:-"doge"}
+export NVM_DIR=${1:-"/home/$USERNAME/.nvm"}
+export NODE_VERSION=${2:-"lts/*"}
+
+set -e
+
+# install all dependencies
+apt-get update \
+    && apt-get install -y curl ca-certificates tar gnupg2 \
+    && apt-get -y autoclean
+
+# install yarn
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+apt-get update
+apt-get -y install --no-install-recommends yarn
+
+# install nvm
+su ${USERNAME} -c "mkdir $NVM_DIR"
+su ${USERNAME} -c "curl --silent -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.36.0/install.sh | bash"
+
+# install node and npm
+su ${USERNAME} -c "source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default"

--- a/.devcontainer/scripts/user.sh
+++ b/.devcontainer/scripts/user.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+USERNAME=${1:-"doge"}
+USER_UID=${2:-1000}
+USER_GID=${3:-$USER_UID}
+
+PACKAGE_LIST="apt-utils \
+        git \
+        htop \
+        curl \
+        wget \
+        unzip \
+        zip \
+        vim \
+        less \
+        sudo \
+        man-db"
+
+# install packages
+apt-get -y install --no-install-recommends ${PACKAGE_LIST}
+
+# add non-root user
+groupadd --gid $USER_GID $USERNAME
+useradd -s /bin/bash --uid $USER_UID --gid $USERNAME -m $USERNAME
+echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
+chmod 0440 /etc/sudoers.d/$USERNAME
+chown ${USERNAME}:${USERNAME} "/home/${USERNAME}/.bashrc"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,22 @@ Navigate to `/kofta`
 - Run `npm i`
 - Run `npm run start:staging` (this tells React to connect to a hosted version of the backend for development purposes)
 
-## Full Local Development
+## Devcontainer Full Local Development
+For VSCode users, we're able to use devcontainers which allows to create development environments that already have all the tools and services configured and ready to go.
+
+### Usage
+
+_Prerequisite: [Install Docker](https://docs.docker.com/install) on your local environment._
+
+To get started, read and follow the instuctions in [Developing inside a Container](https://code.visualstudio.com/docs/remote/containers). The [.devcontainer/](./.devcontainer) directory contains pre-configured `devcontainer.json`, `docker-compose.yml` and `Dockerfile` files, which you can use to set up remote development within a docker container.
+
+- Install the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
+- Open VSCode and bring up the [Command Palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette).
+- Type `Remote-Containers: Open Folder in Container`, this will build the container with Elixir and Node installed, this will also start Postgres and RabbitMQ instances.
+
+> If you need to modify environment variables for kousa, you need to modify them inside `/home/doge/.bashrc` and restart your terminal.
+
+## Manual Full Local Development
 How to run locally:
 
 ### Backend

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,25 @@ To get started, read and follow the instuctions in [Developing inside a Containe
 
 > If you need to modify environment variables for kousa, you need to modify them inside `/home/doge/.bashrc` and restart your terminal.
 
+### Run
+#### `kousa`
+```shell
+$ mix deps.get
+$ mix ecto.migrate
+$ iex -S mix
+```
+#### `shawarma`
+```shell
+$ npm i
+$ npm run build
+$ npm start
+```
+#### `kofta`
+```shell
+$ npm i
+$ npm start
+```
+
 ## Manual Full Local Development
 How to run locally:
 


### PR DESCRIPTION
While trying to contribute on the project and seeing the many steps to build the project locally, I thought I'd make it easier for new contributors by making a [devcontainer](https://code.visualstudio.com/docs/remote/devcontainerjson-reference) that works with VSCode and setup everything automatically with Docker.

You need to have the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension installed:
![image](https://user-images.githubusercontent.com/22665836/112548326-6d189000-8d92-11eb-8fde-e28a3d9bcee9.png)

When opening the repo you'll get the following notification:
![image](https://user-images.githubusercontent.com/22665836/112548426-933e3000-8d92-11eb-87a3-5ce8f5cfd90f.png)

By clicking Reopen in Container this will create a new devcontainer with Elixir, Node, Postgres and RabbitMQ installed.
In `devcontainer.json`
We can set all the ports we want to expose to our local machine (I may be missing some)
```json
"forwardPorts": [
        80,
        3000,
        4001,
        8080,
        5432,
        5672,
        15672
],
```

We can also specify VSCode extensions that will be automatically installed when the container is created, which is a good way to enforce to use extensions like ESLint and Prettier by everyone (I put the ones that were obvious, but we can add more).
```json
"extensions": [
        "dbaeumer.vscode-eslint",
        "esbenp.prettier-vscode",
        "jakebecker.elixir-ls",
        "bradlc.vscode-tailwindcss"
],
```
![image](https://user-images.githubusercontent.com/22665836/112549301-f8465580-8d93-11eb-81f3-fb48c816b910.png)
