### PR TITLE
Push-to-talk fixed in 1.0.21, forgot to update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please read [CONTRIBUTING.md](https://github.com/benawad/dogehouse/blob/staging/
 
 ## DogeHouse Desktop
 
-A desktop app built with electron is available for Windows and Mac
+A desktop app built with electron is available for Windows, Mac, and Linux
 
 Download links are in [the releases section](https://github.com/benawad/dogehouse/releases/latest)
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Built with electron.
 
 __*Notes:*__
 - If a warning message pops up on Windows, go to 'more info' and select 'Run Anyway'
-- Currently Linux builds will install but won't run due to a problem with global keyevents.
 
 ## DogeReviewers
 


### PR DESCRIPTION
Linux push to talk now works since 1.0.21. Probably should've updated my last PR to reflect that. Sorry for the inconvienience