### PR TITLE
Fix copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ben Awad
+Copyright (C) 2021 Ben Awad and the Dogehouse contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2021 Ben Awad and the Dogehouse contributors
+Copyright (C) 2021 Ben Awad and the DogeHouse contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The copyright notice currently only lists Ben Awad as a copyright holder, but copyright notices require the names of all copyright holders of the work to be present. For example, in the U.S., [17 U.S.C. &sect; 401(b)(3)] requires "the name of the [holder] of copyright in the work, or an abbreviation by which the name can be recognized." In this case, ["the Dogehouse contributors" should be sufficient](https://ben.balter.com/2015/06/03/copyright-notices-for-websites-and-open-source-projects/).

(Obligatory "IANAL, this is not legal advice" statement here.)

[17 U.S.C. &sect; 401(b)(3)]: https://www.law.cornell.edu/uscode/text/17/401#b_3