### PR TITLE
Create new_version_bugs.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_version_bugs.md
+++ b/.github/ISSUE_TEMPLATE/new_version_bugs.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report For New DogeHouse Version
+about: Create a report to help us improve
+title: 'New Version Bug: '
+labels: new-version-bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**What device are you on?**
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Per Ben's request a new template for new version bugs has been created.
We need to make a tag for new-version-bugs or I can update the .md file to the normal bugs tag.