### PR TITLE
fix: prevent overscroll bounce

### DIFF
--- a/kibbeh/src/styles/globals.css
+++ b/kibbeh/src/styles/globals.css
@@ -78,3 +78,11 @@ audio {
   width: 0;
   display: none !important;
 }
+
+html {
+  position: fixed;
+}
+
+#__next {
+  overflow: auto;
+}


### PR DESCRIPTION
Sets the root node (#__next) to be the scrolling element and adds a fixed position to the html element, ensuring the browser doesn't overscroll out of the boundaries of the content.

**Before**

![before](https://i.imgur.com/6LwQ83e.gif)

**After**

![after](https://i.imgur.com/M24NjGy.gif)