### PR TITLE
Add link to live version of next.js rewrite

### DIFF
--- a/kibbeh/README.md.save
+++ b/kibbeh/README.md.save
@@ -1,23 +1,16 @@
-<p align="center">
-    <img height=100 src="https://raw.githubusercontent.com/benawad/dogehouse/staging/.redesign-assets/dogehouse_logo.svg"/>
+<p align="center"> <img height=100 src="https://raw.githubusercontent.com/benawad/dogehouse/staging/.redesign-assets/dogehouse_logo.svg"/>
 </p>
 
-<p align="center">
-    <strong>Taking voice conversations to the moon 🚀</strong>
+<p align="center"> <strong>Taking voice conversations to the moon 🚀</strong>
 </p>
 
-<p align="center">
-    <img src="https://img.shields.io/github/contributors/benawad/dogehouse"/>
-    <img src="https://img.shields.io/discord/810571477316403233?label=discord"/>
-    <img src="https://img.shields.io/github/v/release/benawad/dogehouse"/>
-</p>
-<br/>
+<p align="center"> <img src="https://img.shields.io/github/contributors/benawad/dogehouse"/> <img src="https://img.shields.io/discord/810571477316403233?label=discord"/> <img 
+    src="https://img.shields.io/github/v/release/benawad/dogehouse"/>
+</p> <br/>
 
 # What is this folder?
 
 This folder is called kibbeh ([/ˈkɪbi/](https://en.wikipedia.org/wiki/Kibbeh)), it is currently used for our Next.js frontend rewrite and new design.
-
-It's live on 👉 [next.dogehouse.tv](https://next.dogehouse.tv)
 
 # How can I contribute?
 
@@ -27,18 +20,10 @@ First of all, this project is currently in _very_ early stages of development, t
 
 Compile @dogehouse/kebab by executing the following commands:
 
-```bash
-cd ../kebab
-yarn
-yarn build
-```
+```bash cd ../kebab yarn yarn build ```
 
 After you successfully compiled Kebab, go back to this directory and install all modules (@dogehouse/kebab is a yarn workspace, you do <u>not</u> need to manually copy it to node_modules)
 
 You should now be all set to go, go ahead and run the dev server
 
-```bash
-cd ../kibbeh
-yarn
-yarn staging
-```
+```bash cd ../kibbeh yarn yarn staging ```


### PR DESCRIPTION
Added a link in the kibbeh readme to the live version of the next.js rewrite:  [next.dogehouse.tv](https://next.dogehouse.tv)