### PR TITLE
Update auto-update service

### DIFF
--- a/baklava/src/electron.ts
+++ b/baklava/src/electron.ts
@@ -183,7 +183,13 @@ if (!instanceLock) {
   app.on("ready", () => {
     localize().then(() => {
       createWindow();
-      if (__prod__) autoUpdater.checkForUpdates();
+      if (__prod__) {
+        try {
+          autoUpdater.checkForUpdates();
+        } catch (e) {
+          console.error(e);
+        }
+      }
     })
   });
   app.on("second-instance", (event, argv, workingDirectory) => {


### PR DESCRIPTION
It now does nothing when the provider is undefined, this allows users to run the app out of the [platform]-unpacked directory without it freezing at startup