### PR TITLE
Update README.md to reflect an Ubuntu PPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Dogehouse is also available in the AUR
 ```bash
 yay -S dogehouse
 ```
+And as an Ubuntu ppa
+```bash
+curl -s https://packagecloud.io/install/repositories/stratusfearme21/dogehouse/script.deb.sh | sudo bash
+```
 
 __*Notes:*__
 - If a warning message pops up on Windows, go to 'more info' and select 'Run Anyway'

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ yay -S dogehouse
 And as an Ubuntu ppa
 ```bash
 curl -s https://packagecloud.io/install/repositories/stratusfearme21/dogehouse/script.deb.sh | sudo bash
+sudo apt-get install dogehouse
 ```
 
 __*Notes:*__

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ yay -S dogehouse
 ```
 And in an Ubuntu ppa
 ```bash
-curl -s https://packagecloud.io/install/repositories/stratusfearme21/dogehouse/script.deb.sh | sudo bash
+echo "deb [trusted=yes] https://ppa.palomagit.ml/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null
 sudo apt-get install dogehouse
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ yay -S dogehouse
 ```
 And in an Ubuntu ppa
 ```bash
-echo "deb [trusted=yes] https://ppa.palomagit.ml/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null
+echo "deb https://ppa.palomagit.ml/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null
 wget -q -O - https://ppa.palomagit.ml/KEY.gpg | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install dogehouse

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Dogehouse is also available in the AUR
 ```bash
 yay -S dogehouse
 ```
-And as an Ubuntu ppa
+And in an Ubuntu ppa
 ```bash
 curl -s https://packagecloud.io/install/repositories/stratusfearme21/dogehouse/script.deb.sh | sudo bash
 sudo apt-get install dogehouse

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ yay -S dogehouse
 And in an Ubuntu ppa
 ```bash
 echo "deb [trusted=yes] https://ppa.palomagit.ml/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null
+wget -q -O - https://ppa.palomagit.ml/KEY.gpg | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install dogehouse
 ```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ yay -S dogehouse
 And in an Ubuntu ppa
 ```bash
 echo "deb [trusted=yes] https://ppa.palomagit.ml/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null
+sudo apt-get update
 sudo apt-get install dogehouse
 ```
 


### PR DESCRIPTION
I figured that since @amitojsingh366 would like to disable updating on Linux (https://github.com/benawad/dogehouse/pull/1690), then an Ubuntu repository would be critical. I couldn't figure out for the life of me how to use launchpad.net unfortunately, however I did figure out how to self-host my own PPA very easily with my RPi at home. So I updated the README to include this new way to install dogehouse