### PR TITLE
Update PPA in README for http instead of https

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ yay -S dogehouse
 And in an Ubuntu ppa
 
 ```bash
-echo "deb https://ppa.dogehouse.tv/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null
-wget -q -O - https://ppa.dogehouse.tv/KEY.gpg | sudo apt-key add -
+echo "deb http://ppa.dogehouse.tv/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null
+wget -q -O - http://ppa.dogehouse.tv/KEY.gpg | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install dogehouse
 ```


### PR DESCRIPTION
I know I JUST got my previous pull request merged, but I've switched the server to use http instead of https, this is standard for Ubuntu repositories and I didn't realize that until recently. Security across the wire is handled by gpg  in ubuntu, not HTTPS. I'm sorry I didn't realize this the first time