### PR TITLE
fix(kibbeh): fix displayed number of speakers

### DIFF
--- a/kibbeh/src/modules/room/RoomUsersPanel.tsx
+++ b/kibbeh/src/modules/room/RoomUsersPanel.tsx
@@ -18,9 +18,12 @@ if (isElectron()) {
 const isMac = process.platform === "darwin";
 
 export const RoomUsersPanel: React.FC<RoomUsersPanelProps> = (props) => {
-  const { askingToSpeak, listeners, speakers } = useSplitUsersIntoSections(
-    props
-  );
+  const {
+    askingToSpeak,
+    listeners,
+    speakers,
+    canIAskToSpeak,
+  } = useSplitUsersIntoSections(props);
   const { t } = useTypeSafeTranslation();
 
   const [ipcStarted, setIpcStarted] = useState(false);
@@ -57,7 +60,9 @@ export const RoomUsersPanel: React.FC<RoomUsersPanelProps> = (props) => {
       >
         <RoomSectionHeader
           title={t("pages.room.speakers")}
-          tagText={"" + speakers.length}
+          tagText={
+            "" + (canIAskToSpeak ? speakers.length - 1 : speakers.length)
+          }
         />
         {speakers}
         {askingToSpeak.length ? (


### PR DESCRIPTION
Currently the 'ask to speak' button is counted as a speaker, so the count is one more than the
actual number of speakers.

![Untitled - Copy](https://user-images.githubusercontent.com/33333226/113521834-b2b03680-95a4-11eb-8851-57ca1a2931b9.png)