### PR TITLE
Update globkey for new, faster approach (to fix heavy lag on Linux)

### DIFF
--- a/baklava/package.json
+++ b/baklava/package.json
@@ -102,7 +102,7 @@
         "electron-log": "^4.3.2",
         "electron-overlay-window": "^1.0.4",
         "electron-updater": "^4.3.8",
-        "globkey": "^1.0.19",
+        "globkey": "^1.0.21",
         "i18next": "^20.0.0",
         "i18next-node-fs-backend": "^2.1.3"
     },

--- a/baklava/src/utils/keybinds/index.ts
+++ b/baklava/src/utils/keybinds/index.ts
@@ -136,10 +136,6 @@ export function RegisterKeybinds(bWindows: bWindowsType) {
             }
         }
     });
-
-
-    // globkey.raw((keypair: string[]) => {
-
 }
 export async function exitApp() {
     worker.removeAllListeners();

--- a/baklava/src/utils/keybinds/worker.ts
+++ b/baklava/src/utils/keybinds/worker.ts
@@ -2,7 +2,6 @@ import { isMainThread, parentPort } from 'worker_threads';
 import globkey from 'globkey';
 
 if (!isMainThread) {
-    let prev_keys = ['', '']
     let shouldBreak = false;
     globkey.start();
     while (true) {

--- a/baklava/src/utils/keybinds/worker.ts
+++ b/baklava/src/utils/keybinds/worker.ts
@@ -4,12 +4,10 @@ import globkey from 'globkey';
 if (!isMainThread) {
     let prev_keys = ['', '']
     let shouldBreak = false;
+    globkey.start();
     while (true) {
         if (shouldBreak) break;
         let keys = globkey.getKeys();
-        if (keys != prev_keys) {
-            if (parentPort) parentPort.postMessage({ type: 'keys', keys: keys });
-        }
-        prev_keys = keys
+        if (parentPort) parentPort.postMessage({ type: 'keys', keys: keys });
     }
 }

--- a/baklava/yarn.lock
+++ b/baklava/yarn.lock
@@ -1253,7 +1253,7 @@ __metadata:
     electron-log: ^4.3.2
     electron-overlay-window: ^1.0.4
     electron-updater: ^4.3.8
-    globkey: ^1.0.19
+    globkey: ^1.0.21
     i18next: ^20.0.0
     i18next-node-fs-backend: ^2.1.3
     lodash: ^4.17.21
@@ -1836,10 +1836,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globkey@npm:^1.0.19":
-  version: 1.0.19
-  resolution: "globkey@npm:1.0.19"
-  checksum: 610fd1b833992545a112057e019ed48e7107bc114c17c89be941a50b2a84426ada0b5e725d96372ff7aada8fb52c2aa867f759bb660f4be2eccd77b2d06f9a8c
+"globkey@npm:^1.0.21":
+  version: 1.0.21
+  resolution: "globkey@npm:1.0.21"
+  checksum: 98186ae3e195c4d86a63f5f44e92e39bc03c2cdd24937034d12b12e36f8630351e878b44eba1a3736a671808b8fe0a2a32ed1e9eb5ac44a1bdf59b062ebadd8c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<details>
<summary>Long story (if you're intrested)</summary>
Before, globkey simply had 1 function called `getKeys()`, this function called a very expensive rust function every time it was called in js. It didn't create lag on Windows or Mac, but it did on Linux. So I had to find a way to make this work by only calling the expensive function once, and then using it for the rest of runtime. At first this was very difficult since the function couldn't be shared between threads, and in order to be global, it had to. Then, as I was about to open a question on Stack Overflow, @amitojsingh366 told me that he was going to use worker threads in order to implement the `getKeys()` function. Then I had a eureka moment, what if I just made a worker thread in rust, and then used mpsc for communication between rust and js.
</details>

TL;DR: globkey now works like this
- The `start()` function must be called when the app starts
- After that, calling the `getKeys()` function in a loop will get the global key events from the keyboard
- The `unload()` function must be called when the app exits **AND** the worker thread stops calling the `getKeys()` function, otherwise the app may freeze before closing (at least it did for me in testing).

(The functions that were there before still work, just when this PR gets merged they'll be properly deprecated)