### PR TITLE
Fix LgLogo Import

### DIFF
--- a/kibbeh/src/modules/landing-page/LoginPage.tsx
+++ b/kibbeh/src/modules/landing-page/LoginPage.tsx
@@ -9,7 +9,7 @@ import SvgSolidGitHub from "../../icons/SolidGitHub";
 import SvgSolidNew from "../../icons/SolidNew";
 import SvgSolidBug from "../../icons/SolidBug";
 import SvgSolidTwitter from "../../icons/SolidTwitter";
-import { LgLogo } from "../../icons";
+import LgLogo from "../../icons/LgLogo";
 import SvgSolidDiscord from "../../icons/SolidDiscord";
 import { WebSocketContext } from "../ws/WebSocketProvider";
 import { HeaderController } from "../display/HeaderController";


### PR DESCRIPTION
LgLogo.tsx is being improperly imported into the login page as an asset. The import path is simply pointing to `../../icons` and not the actual file which is `../../icons/LgLogo`.

This is a minor change.