### PR TITLE
style:keeps outline when tabbing through but not when focused accidentally

### DIFF
--- a/kibbeh/src/styles/globals.css
+++ b/kibbeh/src/styles/globals.css
@@ -35,6 +35,7 @@ p.bold {
   --color-accent: #fd4d4d;
   --color-accent-hover: #fd6868;
   --color-accent-disabled: #f5bfbf;
+  --outline-accent-disabled: none;
 }
 
 h1 {
@@ -96,4 +97,15 @@ textarea {
 #nprogress {
   position: relative;
   z-index: 9999999;
+}
+/* this applies to all buttons; the buttons not generated without button.tsx will still have no outline, so DO NOT NOT USE BUTTON.TSX */
+
+button:focus-visible {
+  outline:none;
+  /* removes outline when user is not tabbing through */
+}
+
+button:focus {
+  outline:none
+  /* removes outline when user is tabbing through; instead it changes to secondary color in button.tsx */
 }

--- a/kibbeh/src/styles/globals.css
+++ b/kibbeh/src/styles/globals.css
@@ -104,8 +104,3 @@ button:focus-visible {
   outline:none;
   /* removes outline when user is not tabbing through */
 }
-
-button:focus {
-  outline:none
-  /* removes outline when user is tabbing through; instead it changes to secondary color in button.tsx */
-}

--- a/kibbeh/src/ui/Button.tsx
+++ b/kibbeh/src/ui/Button.tsx
@@ -1,3 +1,4 @@
+import { NONAME } from "node:dns";
 import React, {
   ButtonHTMLAttributes,
   DetailedHTMLProps,
@@ -10,13 +11,27 @@ const sizeClassnames = {
   small: "px-2 py-1 text-xs rounded-md",
 };
 
+/* below, the "color classnames" are defined; they are parsed 
+
+for example:
+
+hover:#fafafa
+
+is parsed to (effectively)
+
+button:hover {
+  color: #fafafa
+}
+
+the color classnames will also be made the title of the button in the html */
+
 const colorClassnames = {
   primary:
-    "text-button bg-accent hover:bg-accent-hover disabled:text-accent-disabled disabled:bg-accent-hover",
+    "text-button bg-accent hover:bg-accent-hover focus:bg-accent-hover disabled:text-accent-disabled disabled:bg-accent-hover",
   secondary:
-    "text-button bg-primary-700 hover:bg-primary-600 disabled:text-primary-300",
+    "text-button bg-primary-700 hover:bg-primary-600 focus:bg-primary-600 disabled:text-primary-300",
   "secondary-800":
-    "text-button bg-primary-800 hover:bg-primary-600 disabled:text-primary-300",
+    "text-button bg-primary-800 hover:bg-primary-600 focus:bg-primary-600 disabled:text-primary-300",
 };
 
 export type ButtonProps = DetailedHTMLProps<


### PR DESCRIPTION
style:keeps outline when tabbing through but not when focused accidentally

1. I added documentation to Button.tsx
2. This doesn't affect users that are just tabbing through (on all browsers)
3. multiple people on discord complained that they accidentally focused the button and that the outline is ugly. When focused now, the button switches to the secondary color if it is focused by the mouse, or includes an outline if focused by the keyboard, **and** switches to the secondary color.

--bugless--