### PR TITLE
Fixes emotes and also obama.

### DIFF
--- a/kibbeh/src/lib/createChatMessage.ts
+++ b/kibbeh/src/lib/createChatMessage.ts
@@ -39,7 +39,7 @@ export const createChatMessage = (
     } else if (item.startsWith(":") && item.endsWith(":") && item.length > 2) {
       tokens.push({
         t: "emote",
-        v: item.slice(1, item.length - 1),
+        v: item.slice(1, item.length - 1).toLowerCase(),
       });
     } else {
       tokens.push({

--- a/kibbeh/src/modules/room/chat/EmoteData.ts
+++ b/kibbeh/src/modules/room/chat/EmoteData.ts
@@ -14,7 +14,7 @@ export const customEmojis = [
     imageUrl: "/emotes/brokenHeart.gif",
   },
   {
-    name: "obamium",
+    name: "obama",
     short_names: ["obama"],
     keywords: ["obama", "prism", "obamium"],
     imageUrl: "/emotes/obamium.png",


### PR DESCRIPTION
#1863 lowercases v in tokens in createChatMessage.ts which will make all emotes go out as lowercased even if you typed out with uppercases so it won't matter what the emote menu gets wrong on casing.

Also fixes obama emote, for some reason the emote menu was putting :obama: in the text field when :obamium: is needed to actually display emote, so I just changed name so it would match the short_name and now it will work with :obama: