### PR TITLE
Implement list virtualization for the chat

### DIFF
--- a/kibbeh/package.json
+++ b/kibbeh/package.json
@@ -47,6 +47,7 @@
     "react-popper": "^2.2.5",
     "react-query": "^3.12.2",
     "react-responsive": "^8.2.0",
+    "react-virtual": "^2.6.1",
     "superstruct": "^0.15.1",
     "tslib": "^2.1.0",
     "uuid": "^8.3.2",

--- a/kibbeh/src/modules/room/chat/RoomChatList.tsx
+++ b/kibbeh/src/modules/room/chat/RoomChatList.tsx
@@ -35,7 +35,7 @@ export const RoomChatList: React.FC<ChatListProps> = ({ room }) => {
   });
 
   const rowVirtualizer = useVirtual({
-    overscan: 0,
+    overscan: 10,
     size: messages.length,
     parentRef: chatListRef,
     estimateSize: React.useCallback(() => 20, []),

--- a/kibbeh/src/modules/room/chat/RoomChatList.tsx
+++ b/kibbeh/src/modules/room/chat/RoomChatList.tsx
@@ -1,6 +1,7 @@
 import { Room } from "@dogehouse/kebab";
 import normalizeUrl from "normalize-url";
 import React, { useContext, useEffect, useRef, useState } from "react";
+import { useVirtual, VirtualItem } from "react-virtual";
 import { useConn } from "../../../shared-hooks/useConn";
 import { useCurrentRoomInfo } from "../../../shared-hooks/useCurrentRoomInfo";
 import { useTypeSafeTranslation } from "../../../shared-hooks/useTypeSafeTranslation";
@@ -33,9 +34,16 @@ export const RoomChatList: React.FC<ChatListProps> = ({ room }) => {
     }
   });
 
+  const rowVirtualizer = useVirtual({
+    overscan: 0,
+    size: messages.length,
+    parentRef: chatListRef,
+    estimateSize: React.useCallback(() => 20, []),
+  });
+
   return (
     <div
-      className={`px-5 flex-1 overflow-y-auto flex-col flex chat-message-container scrollbar-thin scrollbar-thumb-primary-700`}
+      className={`px-5 flex-1 overflow-y-auto chat-message-container scrollbar-thin scrollbar-thumb-primary-700`}
       ref={chatListRef}
       onScroll={() => {
         if (!chatListRef.current) return;
@@ -49,131 +57,170 @@ export const RoomChatList: React.FC<ChatListProps> = ({ room }) => {
         }
       }}
     >
-      {messages
-        .slice()
-        .reverse()
-        .map((m, idx) => (
-          <div
-            style={{ marginTop: idx === 0 ? "auto" : undefined }}
-            className={`flex flex-col flex-shrink-0 ${
-              m.isWhisper ? "bg-primary-700 rounded my-1" : ""
-            }`}
-            key={m.id}
-          >
-            {/* Whisper label */}
-            {m.isWhisper ? (
-              <p className="mb-0 text-sm text-primary-300 px-1 w-16 mt-1 text-center">
-                {t("modules.roomChat.whisper")}
-              </p>
-            ) : null}
-            <div className={`flex items-center px-1`}>
+      <div
+        className="w-full h-full mt-auto"
+        style={{
+          height: `${rowVirtualizer.totalSize}px`,
+          width: "100%",
+          position: "relative",
+        }}
+      >
+        {rowVirtualizer.virtualItems.map(
+          ({ index: idx, start, measureRef, size }: VirtualItem) => {
+            const index = messages.length - idx - 1;
+            return (
               <div
-                className={`py-1 block break-words max-w-full items-start flex-1 text-primary-100`}
-                key={m.id}
+                ref={measureRef}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: `translateY(${
+                    messages[index].isWhisper ? start : start
+                  }px)`,
+                }}
+                key={messages[index].id}
+                className="py-1"
               >
-                <button
-                  onClick={() => {
-                    setData({
-                      userId: m.userId,
-                      message:
-                        (me?.id === m.userId ||
-                          iAmCreator ||
-                          (iAmMod && room.creatorId !== m.userId)) &&
-                        !m.deleted
-                          ? m
-                          : undefined,
-                    });
-                  }}
-                  className={`inline hover:underline font-bold focus:outline-none font-mono`}
-                  style={{ textDecorationColor: m.color, color: m.color }}
+                <div
+                  className={`flex flex-col flex-shrink-0 w-full ${
+                    messages[index].isWhisper
+                      ? "bg-primary-700 rounded p-1 pt-0"
+                      : ""
+                  }`}
                 >
-                  {m.username}
-                </button>
+                  {/* Whisper label */}
+                  {messages[index].isWhisper ? (
+                    <p className="mb-0 text-sm text-primary-300 px-1 w-16 mt-1 text-center">
+                      {t("modules.roomChat.whisper")}
+                    </p>
+                  ) : null}
+                  <div className={`flex items-center px-1`}>
+                    <div
+                      className={`block break-words max-w-full items-start flex-1 text-primary-100`}
+                      key={messages[index].id}
+                    >
+                      <button
+                        onClick={() => {
+                          setData({
+                            userId: messages[index].userId,
+                            message:
+                              (me?.id === messages[index].userId ||
+                                iAmCreator ||
+                                (iAmMod &&
+                                  room.creatorId !== messages[index].userId)) &&
+                              !messages[index].deleted
+                                ? messages[index]
+                                : undefined,
+                          });
+                        }}
+                        className={`inline hover:underline font-bold focus:outline-none font-mono`}
+                        style={{
+                          textDecorationColor: messages[index].color,
+                          color: messages[index].color,
+                        }}
+                      >
+                        {messages[index].username}
+                      </button>
+                      <span className={`inline mr-1`}>: </span>
+                      <div className={`inline mr-1 space-x-1`}>
+                        {messages[index].deleted ? (
+                          <span className="inline text-primary-300">
+                            [message{" "}
+                            {messages[index].deleterId ===
+                            messages[index].userId
+                              ? "retracted"
+                              : "deleted"}
+                            ]
+                          </span>
+                        ) : (
+                          messages[index].tokens.map(({ t: token, v }, i) => {
+                            switch (token) {
+                              case "text":
+                                return (
+                                  <React.Fragment
+                                    key={i}
+                                  >{`${v} `}</React.Fragment>
+                                );
+                              case "emote":
+                                return emoteMap[v] ? (
+                                  <img
+                                    key={i}
+                                    className="inline"
+                                    alt={`:${v}:`}
+                                    src={emoteMap[v.toLowerCase()]}
+                                  />
+                                ) : (
+                                  ":" + v + ":"
+                                );
 
-                <span className={`inline mr-1`}>: </span>
-                <div className={`inline mr-1 space-x-1`}>
-                  {m.deleted ? (
-                    <span className="inline text-primary-300">
-                      [message{" "}
-                      {m.deleterId === m.userId ? "retracted" : "deleted"}]
-                    </span>
-                  ) : (
-                    m.tokens.map(({ t: token, v }, i) => {
-                      switch (token) {
-                        case "text":
-                          return (
-                            <React.Fragment key={i}>{`${v} `}</React.Fragment>
-                          );
-                        case "emote":
-                          return emoteMap[v] ? (
-                            <img
-                              key={i}
-                              className="inline"
-                              alt={`:${v}:`}
-                              src={emoteMap[v.toLowerCase()]}
-                            />
-                          ) : (
-                            ":" + v + ":"
-                          );
-
-                        case "mention":
-                          return (
-                            <React.Fragment key={i}>
-                              <button
-                                onClick={() => {
-                                  setData({ userId: v });
-                                }}
-                                className={`inline hover:underline flex-1 focus:outline-none ${
-                                  v === me?.username
-                                    ? "bg-accent text-white px-1 rounded text-md"
-                                    : ""
-                                }`}
-                                style={{
-                                  textDecorationColor: m.color,
-                                  color: v === me?.username ? "" : m.color,
-                                }}
-                              >
-                                @{v}
-                              </button>{" "}
-                            </React.Fragment>
-                          );
-                        case "link":
-                          return (
-                            <a
-                              target="_blank"
-                              rel="noreferrer noopener"
-                              href={v}
-                              className={`inline flex-1 hover:underline text-accent`}
-                              key={i}
-                            >
-                              {normalizeUrl(v, { stripProtocol: true })}{" "}
-                            </a>
-                          );
-                        case "block":
-                          return (
-                            <span key={i}>
-                              <span
-                                className={
-                                  "inline bg-simple-gray-33 rounded whitespace-pre-wrap font-mono"
-                                }
-                              >
-                                {v}
-                              </span>{" "}
-                            </span>
-                          );
-                        default:
-                          return null;
-                      }
-                    })
-                  )}
+                              case "mention":
+                                return (
+                                  <React.Fragment key={i}>
+                                    <button
+                                      onClick={() => {
+                                        setData({ userId: v });
+                                      }}
+                                      className={`inline hover:underline flex-1 focus:outline-none ${
+                                        v === me?.username
+                                          ? "bg-accent text-white px-1 rounded text-md"
+                                          : ""
+                                      }`}
+                                      style={{
+                                        textDecorationColor:
+                                          messages[index].color,
+                                        color:
+                                          v === me?.username
+                                            ? ""
+                                            : messages[index].color,
+                                      }}
+                                    >
+                                      @{v}
+                                    </button>{" "}
+                                  </React.Fragment>
+                                );
+                              case "link":
+                                return (
+                                  <a
+                                    target="_blank"
+                                    rel="noreferrer noopener"
+                                    href={v}
+                                    className={`inline flex-1 hover:underline text-accent`}
+                                    key={i}
+                                  >
+                                    {normalizeUrl(v, { stripProtocol: true })}{" "}
+                                  </a>
+                                );
+                              case "block":
+                                return (
+                                  <span key={i}>
+                                    <span
+                                      className={
+                                        "inline bg-simple-gray-33 rounded whitespace-pre-wrap font-mono"
+                                      }
+                                    >
+                                      {v}
+                                    </span>{" "}
+                                  </span>
+                                );
+                              default:
+                                return null;
+                            }
+                          })
+                        )}
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
-          </div>
-        ))}
-      {/* {messages.length === 0 ? (
+            );
+          }
+        )}
+        {/* {messages.length === 0 ? (
         <div>{t("modules.roomChat.welcomeMessage")}</div>
       ) : null} */}
+      </div>
       <div ref={bottomRef} />
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1804,6 +1804,7 @@ __metadata:
     react-popper: ^2.2.5
     react-query: ^3.12.2
     react-responsive: ^8.2.0
+    react-virtual: ^2.6.1
     style-loader: ^1.3.0
     stylelint: ^13.11.0
     stylelint-config-standard: ^20.0.0
@@ -2558,6 +2559,13 @@ __metadata:
   version: 2.9.2
   resolution: "@popperjs/core@npm:2.9.2"
   checksum: cc4de8b46fc190805619224f1c683bee6a162276430af3728d35087099ad83a80da3c11c4eac7cb2b5aa2fa59d4c7c689e211a3e955136588ed6dedb5bff32c5
+  languageName: node
+  linkType: hard
+
+"@reach/observe-rect@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "@reach/observe-rect@npm:1.2.0"
+  checksum: 4aa32fa1ab410527cecf62e3143664e4b7823212bb7b79b5fd84d0d390fa086fcdba27fceebc0e24e2958f2a0649d5b88ec8b0ed907c72730964ac33eb3089af
   languageName: node
   linkType: hard
 
@@ -15308,6 +15316,18 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-virtual@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "react-virtual@npm:2.6.1"
+  dependencies:
+    "@reach/observe-rect": ^1.1.0
+    ts-toolbelt: ^6.4.2
+  peerDependencies:
+    react: ^16.6.3 || ^17.0.0
+  checksum: 40c281021906f5af0ff9547aafb56f555e17ef4b8584ca3beffb45e0dea7e17e491d173fb23b791a96a4de57af733939e485d8832596dc050a4f4b67cb1657a5
+  languageName: node
+  linkType: hard
+
 "react@npm:17.0.1":
   version: 17.0.1
   resolution: "react@npm:17.0.1"
@@ -17779,6 +17799,13 @@ resolve@^2.0.0-next.3:
     typescript:
       optional: true
   checksum: 78341a27939de565e2754ff65ebb689743c16e3295528089d143c08d91842cf9029c3d6b3c95a9a20854a114a7904329d02c710d63f7ce4dbf671b8a3e560ac1
+  languageName: node
+  linkType: hard
+
+"ts-toolbelt@npm:^6.4.2":
+  version: 6.15.5
+  resolution: "ts-toolbelt@npm:6.15.5"
+  checksum: d2f585ee3439ae7a72dd7c00630491195b2a4f34107c595d567242482b9fa911b5a9b5921fb4984506c2f7d8efce61351c7f48519438df67b6c0a8dcd40c862c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently, all chat messages are appended to the DOM even though they are out of the view port of the chat, this causes a performance issue for huge lists (which is the case of any multiple user chat list), so in this PR I implemented list virtualization using a library called [React Vitrual](https://github.com/tannerlinsley/react-virtual), therefore, the number of items that will be appended to the is is equal to the number of the visible items + a configurable over scan value. 
 
https://user-images.githubusercontent.com/33333226/113923042-bcc67500-97f0-11eb-95fe-5a4da5ef8cc4.mp4

