### PR TITLE
fix(kibbeh): re-focus chat input after selecting an emoji

### DIFF
--- a/kibbeh/src/modules/room/chat/RoomChatInput.tsx
+++ b/kibbeh/src/modules/room/chat/RoomChatInput.tsx
@@ -1,5 +1,5 @@
 import { RoomUser } from "@dogehouse/kebab";
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { Smiley } from "../../../icons";
 import { createChatMessage } from "../../../lib/createChatMessage";
 import { showErrorToast } from "../../../lib/showErrorToast";
@@ -46,6 +46,10 @@ export const RoomChatInput: React.FC<ChatInputProps> = ({ users }) => {
   const slowModeAnimationController = useAnimation();
 
   let position = 0;
+
+  useEffect(() => {
+    if (!open) inputRef.current?.focus();
+  }, [open]);
 
   const handleSubmit = (
     e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement>


### PR DESCRIPTION
If the user opens the emojis panel and selects an emoji, they have to click in input to send the
message which is annoying, so this PR implements the logic of re-focusing the chat input after
selecting an emoji

Before:

https://user-images.githubusercontent.com/33333226/113927119-bbe41200-97f5-11eb-85b5-723ea4252c47.mp4

After:

https://user-images.githubusercontent.com/33333226/113927137-c1d9f300-97f5-11eb-9056-96777c52e172.mp4

