### PR TITLE
Removes unneeded map that makes overhead & obama.

### DIFF
--- a/kibbeh/src/modules/room/chat/EmoteData.ts
+++ b/kibbeh/src/modules/room/chat/EmoteData.ts
@@ -14,7 +14,7 @@ export const customEmojis = [
     imageUrl: "/emotes/brokenHeart.gif",
   },
   {
-    name: "obamium",
+    name: "obama",
     short_names: ["obama"],
     keywords: ["obama", "prism", "obamium"],
     imageUrl: "/emotes/obamium.png",
@@ -1551,7 +1551,7 @@ export const customEmojis = [
     keywords: ["dough", "doge", "pizza"],
     imageUrl: "/emotes/doughdoge.png",
   },
-].map((item) => ({ ...item, name: item.name.toLowerCase() }));
+];
 
 export const emoteMap: Record<string, string> = {};
 


### PR DESCRIPTION
Removed map on json in EmoteData because it creates unneeded overhead.
The whole point of making the json `name` and `short_name` lowercase was to prevent overhead with iterating over a string and this map defeats the purpose of the whole thing.

Also changes `name: "obamium"` to `name: "obama"` because when using the emote menu and clicking the obama emote, it populates text field with ":obama:" which isn't the correct name to display the emote. Changing the name to "obama" will make that wrong emote menu ":obama:" text work.