### PR TITLE
Added Discord Rich Presence in Baklava 🚀🌌

### DIFF
--- a/baklava/package.json
+++ b/baklava/package.json
@@ -83,6 +83,7 @@
         "extends": null
     },
     "devDependencies": {
+        "@types/discord-rpc": "^3.0.5",
         "@types/i18next-node-fs-backend": "^2.1.0",
         "@types/lodash": "^4.14.168",
         "@types/node": "^14.14.31",
@@ -100,6 +101,7 @@
         "typescript": "^4.2.2"
     },
     "dependencies": {
+        "discord-rpc": "^3.2.0",
         "electron-log": "^4.3.2",
         "electron-overlay-window": "^1.0.4",
         "electron-updater": "^4.3.8",

--- a/baklava/src/utils/discord-rich-presence.ts
+++ b/baklava/src/utils/discord-rich-presence.ts
@@ -1,0 +1,40 @@
+import DiscordRPC from 'discord-rpc';
+
+/* Discord Client Id in developer portal */
+const clientId = '829642922726129694'; /* To be changed to official DogeHouse discord application for discord login */
+
+/* Image key that is added to the developer portal */
+const assetId = 'icon';
+
+/* Discord Presence Message for in menus and inside a room */
+const defaultMessage: DiscordRPC.Presence = { largeImageKey: assetId, details: 'In Menu' };
+const inRoomMessage: DiscordRPC.Presence = { largeImageKey: assetId, details: 'In Room' };
+
+export default class DiscordPresence {
+    client: DiscordRPC.Client
+    constructor() {
+        /* Define the RPC Client */
+        this.client = new DiscordRPC.Client({ transport: 'ipc' });
+        this.client.on('ready', () => {
+            /* Set default message */
+            this.client.setActivity(defaultMessage);
+        })
+    }
+
+    check(url: string) {
+        if (!this.client) return;
+        if (url.match(/\/room\//)) { /* If in room */
+            this.client.setActivity(inRoomMessage);
+        } else {
+            this.client.setActivity(defaultMessage);
+        }
+    }
+
+    shutDown() {
+        this.client.destroy();
+    }
+
+    login() {
+        this.client.login({ clientId: clientId });
+    }
+}

--- a/baklava/yarn.lock
+++ b/baklava/yarn.lock
@@ -169,6 +169,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/discord-rpc@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@types/discord-rpc@npm:3.0.5"
+  checksum: 29419dc98e477890e02c572582ecdb5495a029b2e4c76fd15fb04bb688ed93b0bf54fcc09ad9fa15241e440022cca8c16cc1a9264e5aff583bbc830c48b587b6
+  languageName: node
+  linkType: hard
+
 "@types/fs-extra@npm:^9.0.7":
   version: 9.0.10
   resolution: "@types/fs-extra@npm:9.0.10"
@@ -1189,6 +1196,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"discord-rpc@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "discord-rpc@npm:3.2.0"
+  dependencies:
+    node-fetch: ^2.6.1
+    ws: ^7.3.1
+  peerDependencies:
+    register-scheme: "*"
+  checksum: 40b07dab1801c46cc5b29c153f20aa3c7b41f681169abb9069f5692078dd877c84dc8721bf6650c3a699fad67a523aa415b9b376372c7e78a0075a39b6501617
+  languageName: node
+  linkType: hard
+
 "dmg-builder@npm:22.10.5":
   version: 22.10.5
   resolution: "dmg-builder@npm:22.10.5"
@@ -1230,12 +1249,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "dogehouse@workspace:."
   dependencies:
+    "@types/discord-rpc": ^3.0.5
     "@types/i18next-node-fs-backend": ^2.1.0
     "@types/lodash": ^4.14.168
     "@types/node": ^14.14.31
     "@types/prettier": ^2.2.3
     builder-util: ^22.10.5
     del-cli: ^3.0.1
+    discord-rpc: ^3.2.0
     electron: ^11.3.0
     electron-build-env: ^0.2.0
     electron-builder: ^22.10.5
@@ -2786,6 +2807,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-fetch@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "node-fetch@npm:2.6.1"
+  checksum: cbb171635e538162b977eac5dfe7a1e07a9a02e991924377a6435502291e2f823d306b95aabc455caebf4a118ccf836868462bc70ccc3095af02bb9da61fda37
+  languageName: node
+  linkType: hard
+
 "node-gyp-build@npm:4.x.x":
   version: 4.2.3
   resolution: "node-gyp-build@npm:4.2.3"
@@ -4093,6 +4121,21 @@ typescript@^4.2.2:
     signal-exit: ^3.0.2
     typedarray-to-buffer: ^3.1.5
   checksum: a26a8699c30cdc81d041b2c1049c6773f1e8401edda365874e9ca2dcf1fcf024dfeb43eea5e08c2e9b4e77be08a160d37f8d6c5d8c2d3ceccdf3d06e5cb38d35
+  languageName: node
+  linkType: hard
+
+"ws@npm:^7.3.1":
+  version: 7.4.4
+  resolution: "ws@npm:7.4.4"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: ad08761ed753cdd3f7172e9a9efc7d74e7e196623cace2380e5f74ff0abd16196e03223bd4148a34278dcbc653ee3841994635419281cbf303b3f22c589e2ec4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This feature adds Discord rich presence support (#1549) in the Electron wrapper/Baklava. Currently uses my own application but a future official DogeHouse discord application for things like OAuth would be attached here instead (and requires an icon to be added in the portal).

**Preview**
In Menus/Dashboard
![2](https://user-images.githubusercontent.com/50546858/114008500-96d9b880-9862-11eb-8c64-1d9efefe9585.png)

In a room
![1](https://user-images.githubusercontent.com/50546858/114008447-87f30600-9862-11eb-9e01-736e2fb8a481.png)

The current problem is that fetching information about a room or all rooms requires you to sign in via either your own account or via a bot account. Ben will add an endpoint for fetching metadata from a room to be used in the header tags in Kibbeh. Once he has done that it allows for things like this:
![3](https://user-images.githubusercontent.com/50546858/114008853-eae49d00-9862-11eb-9c12-df11bc950a0f.png)

Any contribution and reviews of this pull request would be highly appreciated. :)