### PR TITLE
fix: add "waytoodank" to the waytoodank emote keywords

### DIFF
--- a/kibbeh/src/modules/room/chat/EmoteData.ts
+++ b/kibbeh/src/modules/room/chat/EmoteData.ts
@@ -164,7 +164,7 @@ export const customEmojis = [
   {
     name: "waytoodank",
     short_names: ["WAYTOODANK"],
-    keywords: ["dank", "feelsdankman"],
+    keywords: ["dank", "feelsdankman", "waytoodank"],
     imageUrl: "/emotes/waytoodank.gif",
   },
   {

--- a/kofta/src/app/modules/room-chat/EmoteData.ts
+++ b/kofta/src/app/modules/room-chat/EmoteData.ts
@@ -166,7 +166,7 @@ export const customEmojis = [
   {
     name: "WAYTOODANK",
     short_names: ["WAYTOODANK"],
-    keywords: ["dank", "feelsdankman"],
+    keywords: ["dank", "feelsdankman", "waytoodank"],
     imageUrl: "/emotes/WAYTOODANK.gif",
   },
   {

--- a/pilaf/src/modules/room/chat/EmoteData.ts
+++ b/pilaf/src/modules/room/chat/EmoteData.ts
@@ -166,7 +166,7 @@ export const customEmojis = [
   {
     name: "WAYTOODANK",
     short_names: ["WAYTOODANK"],
-    keywords: ["dank", "feelsdankman"],
+    keywords: ["dank", "feelsdankman", "waytoodank"],
     imageUrl: require("../../../assets/images/emotes/waytoodank.gif"),
   },
   {


### PR DESCRIPTION
Added "waytoodank" to the waytoodank emote keywords
Related to issue [https://github.com/benawad/dogehouse/issues/1914](https://github.com/benawad/dogehouse/issues/1914)