### PR TITLE
WIP: Visual keybind representation.

### DIFF
--- a/kibbeh/src/modules/keyboard-shortcuts/ChatKeybind.tsx
+++ b/kibbeh/src/modules/keyboard-shortcuts/ChatKeybind.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { recordKeyCombination } from "react-hotkeys";
 import { useKeyMapStore } from "../../global-stores/useKeyMapStore";
 import { Button } from "../../ui/Button";
+import {VisualKeybind} from "./VisualKeybind";
 
 interface ChatKeybindProps {
   className?: string;
@@ -39,7 +40,7 @@ export const ChatKeybind: React.FC<ChatKeybindProps> = ({ className }) => {
       <div className={`ml-4`}>
         toggle chat keybind:{" "}
         <span className={`font-bold text-lg`}>
-          {active ? "listening" : CHAT}
+          {active ? "listening" : <VisualKeybind keybind={CHAT.toString()} />}
         </span>
       </div>
     </div>

--- a/kibbeh/src/modules/keyboard-shortcuts/InviteKeybind.tsx
+++ b/kibbeh/src/modules/keyboard-shortcuts/InviteKeybind.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { recordKeyCombination } from "react-hotkeys";
 import { useKeyMapStore } from "../../global-stores/useKeyMapStore";
 import { Button } from "../../ui/Button";
+import {VisualKeybind} from "./VisualKeybind";
 
 interface InviteKeybindProps {
   className?: string;
@@ -39,7 +40,7 @@ export const InviteKeybind: React.FC<InviteKeybindProps> = ({ className }) => {
       <div className={`ml-4`}>
         invite keybind:{" "}
         <span className={`font-bold text-lg`}>
-          {active ? "listening" : INVITE}
+          {active ? "listening" : <VisualKeybind keybind={INVITE.toString()} />}
         </span>
       </div>
     </div>

--- a/kibbeh/src/modules/keyboard-shortcuts/MuteKeybind.tsx
+++ b/kibbeh/src/modules/keyboard-shortcuts/MuteKeybind.tsx
@@ -3,6 +3,7 @@ import { recordKeyCombination } from "react-hotkeys";
 import { useKeyMapStore } from "../../global-stores/useKeyMapStore";
 import { useTypeSafeTranslation } from "../../shared-hooks/useTypeSafeTranslation";
 import { Button } from "../../ui/Button";
+import { VisualKeybind } from "./VisualKeybind";
 
 interface MuteKeybindProps {
   className?: string;
@@ -41,7 +42,7 @@ export const MuteKeybind: React.FC<MuteKeybindProps> = ({ className }) => {
       <div className={`ml-4`}>
         {t("components.keyboardShortcuts.toggleMuteKeybind")}:{" "}
         <span className={`font-bold text-lg`}>
-          {active ? t("components.keyboardShortcuts.listening") : MUTE}
+          {active ? t("components.keyboardShortcuts.listening") : <VisualKeybind keybind={MUTE.toString()} />}
         </span>
       </div>
     </div>

--- a/kibbeh/src/modules/keyboard-shortcuts/OverlayKeybind.tsx
+++ b/kibbeh/src/modules/keyboard-shortcuts/OverlayKeybind.tsx
@@ -3,6 +3,7 @@ import { recordKeyCombination } from "react-hotkeys";
 import { useKeyMapStore } from "../../global-stores/useKeyMapStore";
 import { useTypeSafeTranslation } from "../../shared-hooks/useTypeSafeTranslation";
 import { Button } from "../../ui/Button";
+import {VisualKeybind} from "./VisualKeybind";
 
 interface OverlayKeybindProps {
   className?: string;
@@ -43,7 +44,7 @@ export const OverlayKeybind: React.FC<OverlayKeybindProps> = ({
       <div className={`ml-4`}>
         {t("components.keyboardShortcuts.toggleOverlayKeybind")}:{" "}
         <span className={`font-bold text-lg`}>
-          {active ? t("components.keyboardShortcuts.listening") : OVERLAY}
+          {active ? t("components.keyboardShortcuts.listening") : <VisualKeybind keybind={OVERLAY.toString()} />}
         </span>
       </div>
     </div>

--- a/kibbeh/src/modules/keyboard-shortcuts/PTTKeybind.tsx
+++ b/kibbeh/src/modules/keyboard-shortcuts/PTTKeybind.tsx
@@ -3,6 +3,7 @@ import { recordKeyCombination } from "react-hotkeys";
 import { useKeyMapStore } from "../../global-stores/useKeyMapStore";
 import { useTypeSafeTranslation } from "../../shared-hooks/useTypeSafeTranslation";
 import { Button } from "../../ui/Button";
+import {VisualKeybind} from "./VisualKeybind";
 
 interface PTTKeybindProps {
   className?: string;
@@ -41,7 +42,7 @@ export const PTTKeybind: React.FC<PTTKeybindProps> = ({ className }) => {
       <div className={`ml-4`}>
         {t("components.keyboardShortcuts.togglePushToTalkKeybind")}:{" "}
         <span className={`font-bold text-lg`}>
-          {active ? t("components.keyboardShortcuts.listening") : PTT}
+          {active ? t("components.keyboardShortcuts.listening") : <VisualKeybind keybind={PTT.toString()} />}
         </span>
       </div>
     </div>

--- a/kibbeh/src/modules/keyboard-shortcuts/RequestToSpeakKeybind.tsx
+++ b/kibbeh/src/modules/keyboard-shortcuts/RequestToSpeakKeybind.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { recordKeyCombination } from "react-hotkeys";
 import { useKeyMapStore } from "../../global-stores/useKeyMapStore";
 import { Button } from "../../ui/Button";
+import {VisualKeybind} from "./VisualKeybind";
 
 interface RequestToSpeakKeybindProps {
   className?: string;
@@ -41,7 +42,7 @@ export const RequestToSpeakKeybind: React.FC<RequestToSpeakKeybindProps> = ({
       <div className={`ml-4`}>
         request to speak keybind:{" "}
         <span className={`font-bold text-lg`}>
-          {active ? "listening" : REQUEST_TO_SPEAK}
+          {active ? "listening" : <VisualKeybind keybind={REQUEST_TO_SPEAK.toString()} />}
         </span>
       </div>
     </div>

--- a/kibbeh/src/modules/keyboard-shortcuts/VisualKeybind.tsx
+++ b/kibbeh/src/modules/keyboard-shortcuts/VisualKeybind.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+interface VisualKeybindProps {
+  keybind: string;
+}
+
+interface KeybindProperties {
+  special: boolean;
+  text: string;
+}
+
+function orderBySpecial(a: KeybindProperties, b: KeybindProperties) {
+  if (a.special && !b.special) {
+    return -1;
+  } else if(a.special && b.special) {
+    return 0;
+  }
+  return 1;
+}
+
+function getButtonProperties(button: string) : KeybindProperties {
+  const shortcutMap = new Map<string, string>();
+  shortcutMap.set('control', 'Ctrl');
+  shortcutMap.set('shift', 'Shift');
+  shortcutMap.set('meta', 'Cmd');
+  shortcutMap.set('tab', 'Tab');
+  shortcutMap.set('alt', 'Alt');
+  shortcutMap.set('enter', 'Enter');
+  shortcutMap.set('backspace', 'Backspace');
+  shortcutMap.set('delete', 'Del');
+
+  const special = shortcutMap.has(button.toLowerCase());
+  const text = special ? (shortcutMap.get(button.toLowerCase()) || button) : button;
+  return { special, text };
+}
+
+export const VisualKeybind: React.FC<VisualKeybindProps> = ({ keybind }) => {
+  const buttons = keybind
+    .split('+')
+    .map((button: string) => getButtonProperties(button))
+    .sort(orderBySpecial);
+
+  const styles = {
+    button: {
+      padding: '.25em .75em',
+      fontSize: '.85em',
+      border: '1px solid white',
+      borderRadius: '.25em',
+      margin: '-.25em .75em 0 .75em',
+    }
+  };
+
+  return (
+    <>
+      {
+        buttons.map((button: KeybindProperties, index: number) => {
+          const hasNext = index < buttons.length - 1;
+          return (
+            <>
+              <span style={styles.button} key={`keybind-icon-${index}-${button}`}>
+                {button.text}
+              </span>
+              {hasNext && "+"}
+            </>
+          );
+        })
+      }
+    </>
+  );
+};


### PR DESCRIPTION
The patch aims to add a visual representation of the set keybinds (as outlined in #1929)

At the moment the implementation is just a rough draft of what the outcome should look like. Some help would be needed to put the CSS in correct place and possibly target some issues with different modifier keys (ctrl, alt etc.)

# Help needed