### PR TITLE
fix(useroomchatstore): updated the clearChat method to also empty the…

### DIFF
--- a/kofta/src/app/modules/room-chat/useRoomChatStore.ts
+++ b/kofta/src/app/modules/room-chat/useRoomChatStore.ts
@@ -100,6 +100,7 @@ export const useRoomChatStore = create(
           messages: [],
           newUnreadMessages: false,
           bannedUserIdMap: {},
+          message: ""
         }),
       reset: () =>
         set({


### PR DESCRIPTION
… message string on room change

The chat message draft was not being updated on a room change. The clearChat method was updated to
also empty the message string when a room change occurs.

fix #1905