### PR TITLE
Fixed EmojiPicker to use full-width of the parent container

### DIFF
--- a/kibbeh/src/ui/EmojiPicker.tsx
+++ b/kibbeh/src/ui/EmojiPicker.tsx
@@ -66,7 +66,7 @@ export const EmojiPicker: React.FC<EmojiPickerProps> = ({
       className={`bg-primary-700 rounded-8 flex flex-row flex-grow p-1 max-h-24 pt-2 px-2`}
     >
       <div
-        className={`grid grid-cols-7 pr-3 gap-2 max-h-16 overflow-y-scroll scrollbar-thin scrollbar-thumb-rounded-xl scrollbar-thumb-primary-800`}
+        className={`grid grid-cols-7 w-full pr-3 gap-2 max-h-16 overflow-y-scroll scrollbar-thin scrollbar-thumb-rounded-xl scrollbar-thumb-primary-800`}
       >
         {(queryMatches.length ? queryMatches : emojiSet).map((emoji) => (
           <img


### PR DESCRIPTION
This changes the behaviour of the component on mobile from this:
![emojipicker-before](https://user-images.githubusercontent.com/57922435/114281283-d4df0400-9a3d-11eb-8557-0ae78643833d.png)

To this:
![emojipicker-after](https://user-images.githubusercontent.com/57922435/114281281-d3add700-9a3d-11eb-81f8-2b66b5e9dd92.png)

fixes #1915