### PR TITLE
Fixing FollowersOnline typo.

### DIFF
--- a/kibbeh/src/ui/FollowersOnline.tsx
+++ b/kibbeh/src/ui/FollowersOnline.tsx
@@ -21,7 +21,7 @@ export interface FriendsOnlineProps {
   showMoreAction?: MouseEventHandler<HTMLDivElement>;
 }
 
-export const FollowerOnline: React.FC<UserWithFollowInfo> = ({
+export const FollowersOnline: React.FC<UserWithFollowInfo> = ({
   username,
   avatarUrl: avatar,
   online,


### PR DESCRIPTION
This component have been imported as FollowersOnline. I assume that is because the name is "FollowersOnline.tsx" but was exported as "FollowerOnline".
this was generating warnings with storybook, and others linters