### PR TITLE
style(createscheduledroommodal): the Date input functions as a button…

### DIFF
--- a/kibbeh/src/modules/scheduled-rooms/CreateScheduledRoomModal.tsx
+++ b/kibbeh/src/modules/scheduled-rooms/CreateScheduledRoomModal.tsx
@@ -106,6 +106,7 @@ export const CreateScheduleRoomModal: React.FC<CreateRoomModalProps> = ({
                 />
                 <div className={`mt-4 w-full flex-col`}>
                   <DateTimePicker
+                    className={`cursor-pointer`}
                     value={values.scheduledFor}
                     minDate={new Date()}
                     maxDate={add(new Date(), { months: 6 })}

--- a/kibbeh/src/styles/globals.css
+++ b/kibbeh/src/styles/globals.css
@@ -125,3 +125,7 @@ img.emoji {
   margin: 0 0.05em 0 0.1em;
   vertical-align: -0.1em;
 }
+
+.cursor-pointer input[type=text] {
+  cursor: pointer;
+}


### PR DESCRIPTION
… but didn't have cursor-pointer

I've changed the cursor styling to pointer for Datepicker in CreateScheduledRoomModal. The input
functions as a button so I thought that it should have a cursor pointer