### PR TITLE
fix(kibbeh): stop messages slicing if the mouse is over that chat list

### DIFF
--- a/kibbeh/src/modules/room/chat/RoomChatList.tsx
+++ b/kibbeh/src/modules/room/chat/RoomChatList.tsx
@@ -16,7 +16,7 @@ interface ChatListProps {
 
 export const RoomChatList: React.FC<ChatListProps> = ({ room }) => {
   const { setData } = useContext(UserPreviewModalContext);
-  const messages = useRoomChatStore((s) => s.messages);
+  const { messages, toggleFrozen } = useRoomChatStore();
   const me = useConn().user;
   const { isMod: iAmMod, isCreator: iAmCreator } = useCurrentRoomInfo();
   const bottomRef = useRef<null | HTMLDivElement>(null);
@@ -56,6 +56,8 @@ export const RoomChatList: React.FC<ChatListProps> = ({ room }) => {
           useRoomChatMentionStore.getState().resetIAmMentioned();
         }
       }}
+      onMouseEnter={toggleFrozen}
+      onMouseLeave={toggleFrozen}
     >
       <div
         className="w-full h-full mt-auto"

--- a/kibbeh/src/modules/room/chat/useRoomChatStore.ts
+++ b/kibbeh/src/modules/room/chat/useRoomChatStore.ts
@@ -74,6 +74,7 @@ export const useRoomChatStore = create(
       newUnreadMessages: false,
       message: "" as string,
       isRoomChatScrolledToTop: false,
+      frozen: false,
     },
     (set) => ({
       addBannedUser: (userId: string) =>
@@ -86,9 +87,9 @@ export const useRoomChatStore = create(
           newUnreadMessages: !s.open,
           messages: [
             { ...m, color: generateColorFromString(m.userId) },
-            ...(s.messages.length > 100
-              ? s.messages.slice(0, 100)
-              : s.messages),
+            ...(s.messages.length <= 100 || s.frozen
+              ? s.messages
+              : s.messages.slice(0, 100)),
           ],
         })),
       setMessages: (messages: RoomChatMessage[]) =>
@@ -132,6 +133,7 @@ export const useRoomChatStore = create(
         set({
           isRoomChatScrolledToTop,
         }),
+      toggleFrozen: () => set((s) => ({ frozen: !s.frozen })),
     })
   )
 );


### PR DESCRIPTION
This is my attempt to solve #1919. Basically, what I did is stopping messages array from being sliced if the mouse is hovering over that chat list (could be accompanied with a button hold), so the indexes of the messages are maintained, and the slicing is resumed once the mouse leaves the chat list.

This behavior is not necessarily the best, however, it solves the problem temporarily. 

https://user-images.githubusercontent.com/33333226/114468672-87f15e00-9bf4-11eb-9696-908a83a38a9d.mp4

