### PR TITLE
Fix UI inconsistencies

### DIFF
--- a/kibbeh/public/locales/en/translation.json
+++ b/kibbeh/public/locales/en/translation.json
@@ -175,7 +175,7 @@
     },
     "upcomingRoomsCard": {
       "upcomingRooms": "Upcoming rooms",
-      "exploreMoreRooms": "Explore More Rooms"
+      "exploreMoreRooms": "Explore more rooms"
     },
     "addToCalendar": {
       "add": "Add to Calendar"

--- a/kibbeh/src/ui/UpcomingRoomsCard.tsx
+++ b/kibbeh/src/ui/UpcomingRoomsCard.tsx
@@ -55,7 +55,7 @@ export const ScheduledRoomSummaryCard: React.FC<ScheduledRoomSummaryCardProps> =
   return (
     <button
       onClick={onClick}
-      className={`px-4 py-2 w-full bg-primary-800 flex flex-col gap-2 border-b border-primary-600 cursor-pointer ${
+      className={`px-4 py-2 w-full bg-primary-800 flex flex-col gap-2 border-b border-primary-600 cursor-pointer last:border-b-0 ${
         transition ? `transition duration-200 ease-in-out` : ``
       } hover:bg-primary-700 z-0`}
     >
@@ -70,17 +70,19 @@ export const UpcomingRoomsCard: React.FC<UpcomingRoomsCardProps> = ({
   onCreateScheduledRoom,
   rooms,
 }) => {
-  const { t } = useTypeSafeTranslation()
+  const { t } = useTypeSafeTranslation();
   return (
     <div className="w-full rounded-lg overflow-y-auto flex flex-col">
-      <div className="px-4 py-2 bg-primary-800 border-b border-primary-600 flex justify-between items-center">
-        <h4 className="text-primary-100 font-bold">{t("components.upcomingRoomsCard.upcomingRooms")}</h4>
+      <div className="px-4 py-3 bg-primary-800 border-b border-primary-600 flex justify-between items-center">
+        <h4 className="text-primary-100 font-bold">
+          {t("components.upcomingRoomsCard.upcomingRooms")}
+        </h4>
         <BoxedIcon
           onClick={onCreateScheduledRoom}
-          style={{ height: "30px", width: "30px" }}
+          style={{ height: "26px", width: "26px" }}
           transition
         >
-          <SolidPlus />
+          <SolidPlus width={12} height={12} />
         </BoxedIcon>
       </div>
       <div className="flex-col">

--- a/kibbeh/src/ui/UserSummaryCard.tsx
+++ b/kibbeh/src/ui/UserSummaryCard.tsx
@@ -72,14 +72,14 @@ export const UserSummaryCard: React.FC<UserSummaryCardProps> = ({
   isOnline,
   avatarUrl,
 }) => {
-  const { t } = useTypeSafeTranslation()
+  const { t } = useTypeSafeTranslation();
   return (
     <div className="flex-col rounded-8 bg-primary-800 p-4 w-full">
       <button onClick={onClick}>
         <div>
           <SingleUser size="default" isOnline={isOnline} src={avatarUrl} />
         </div>
-        <div>
+        <div className="mt-2">
           <div className="flex-col ml-3">
             <span className="text-sm text-primary-100 font-bold break-all text-left">
               {displayName}
@@ -97,7 +97,9 @@ export const UserSummaryCard: React.FC<UserSummaryCardProps> = ({
             <span className="text-primary-100 font-bold">
               {kFormatter(numFollowers)}
             </span>{" "}
-            <span className="text-primary-300 ml-1 lowercase">{t("pages.viewUser.followers")}</span>
+            <span className="text-primary-300 ml-1 lowercase">
+              {t("pages.viewUser.followers")}
+            </span>
           </ApiPreloadLink>
         </div>
         <div className="ml-4">
@@ -105,7 +107,9 @@ export const UserSummaryCard: React.FC<UserSummaryCardProps> = ({
             <span className="text-primary-100 font-bold">
               {kFormatter(numFollowing)}
             </span>
-            <span className="text-primary-300 ml-1 lowercase">{t("pages.viewUser.following")}</span>
+            <span className="text-primary-300 ml-1 lowercase">
+              {t("pages.viewUser.following")}
+            </span>
           </ApiPreloadLink>
         </div>
       </div>

--- a/kibbeh/tailwind.config.js
+++ b/kibbeh/tailwind.config.js
@@ -70,6 +70,7 @@ module.exports = {
     },
     borderWidth: {
       DEFAULT: "1px",
+      0: "0px",
     },
     extend: {
       borderRadius: {
@@ -77,14 +78,17 @@ module.exports = {
         8: "8px",
       },
       outline: {
-        "no-chrome": 'none',
-      }
+        "no-chrome": "none",
+      },
     },
   },
   variants: {
     backgroundColor: ({ after }) => after(["disabled"]),
     textColor: ({ after }) => after(["disabled"]),
     scrollbar: ["rounded", "dark"],
+    extend: {
+      borderWidth: ["last"],
+    },
   },
-  plugins: [require("tailwind-scrollbar"), require('@tailwindcss/line-clamp')],
+  plugins: [require("tailwind-scrollbar"), require("@tailwindcss/line-clamp")],
 };


### PR DESCRIPTION
This PR fixes the following inconsistencies:

1. User display name and username margin top.
2. Upcoming rooms header padding.
3. Create an upcoming room button size.
4. Border bottom for the last upcoming room.
5. `Explore More Rooms` casing.

`UserSummaryCard`:
![user-summary-card-before](https://user-images.githubusercontent.com/33333226/114481833-17efd180-9c0e-11eb-86df-4ccb2beeea79.png)
![user-summary-card-after](https://user-images.githubusercontent.com/33333226/114481847-1faf7600-9c0e-11eb-9772-cf5a6587db87.png)

`UpcommingRoomsCard`:
![upcoming-rooms-before](https://user-images.githubusercontent.com/33333226/114481837-19b99500-9c0e-11eb-96fd-1328f15bcf5f.png)
![upcoming-rooms-after](https://user-images.githubusercontent.com/33333226/114481857-22aa6680-9c0e-11eb-9770-b0b93fdfd0fa.png)