### PR TITLE
Fixes #1927 - Toast if mic access not granted

### DIFF
--- a/kibbeh/src/modules/room/RoomPanelController.tsx
+++ b/kibbeh/src/modules/room/RoomPanelController.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useCurrentRoomIdStore } from "../../global-stores/useCurrentRoomIdStore";
 import { useConn } from "../../shared-hooks/useConn";
 import { CenterLoader } from "../../ui/CenterLoader";
@@ -12,6 +12,10 @@ import { UserPreviewModal } from "./UserPreviewModal";
 import { HeaderController } from "../display/HeaderController";
 import { useRoomChatStore } from "./chat/useRoomChatStore";
 import { useScreenType } from "../../shared-hooks/useScreenType";
+import { useCurrentRoomInfo } from "../../shared-hooks/useCurrentRoomInfo";
+import { showErrorToast } from "../../lib/showErrorToast";
+import { useDevices } from "../../shared-hooks/useDevices";
+import { useTypeSafeTranslation } from "../../shared-hooks/useTypeSafeTranslation";
 
 interface RoomPanelControllerProps {}
 
@@ -20,8 +24,17 @@ export const RoomPanelController: React.FC<RoomPanelControllerProps> = ({}) => {
   const { currentRoomId } = useCurrentRoomIdStore();
   const [showEditModal, setShowEditModal] = useState(false);
   const { data, isLoading } = useGetRoomByQueryParam();
+  const { canSpeak } = useCurrentRoomInfo();
+  const { devices } = useDevices();
   const open = useRoomChatStore((s) => s.open);
   const screenType = useScreenType();
+  const { t } = useTypeSafeTranslation();
+
+  useEffect(() => {
+    if (canSpeak && devices.length === 0) {
+      showErrorToast(t("pages.voiceSettings.permissionError"));
+    }
+  }, []);
 
   if (isLoading || !currentRoomId) {
     return (

--- a/kibbeh/src/modules/settings/VoiceSettingsPage.tsx
+++ b/kibbeh/src/modules/settings/VoiceSettingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useGlobalVolumeStore } from "../../global-stores/useGlobalVolumeStore";
 import { useTypeSafeTranslation } from "../../shared-hooks/useTypeSafeTranslation";
 import { PageComponent } from "../../types/PageComponent";
@@ -17,15 +17,15 @@ import { MiddlePanel } from "../layouts/GridPanels";
 import { useMicIdStore } from "../webrtc/stores/useMicIdStore";
 import { HeaderController } from "../../modules/display/HeaderController";
 import isElectron from "is-electron";
+import { useDevices } from "../../shared-hooks/useDevices";
 
 interface VoiceSettingsProps {}
 
 export const VoiceSettingsPage: PageComponent<VoiceSettingsProps> = () => {
   const { micId, setMicId } = useMicIdStore();
   const { volume, set } = useGlobalVolumeStore();
-  const [devices, setDevices] = useState<Array<{ id: string; label: string }>>(
-    []
-  );
+  const { devices, fetchMics } = useDevices();
+
   useEffect(() => {
     if (isElectron()) {
       const ipcRenderer = window.require("electron").ipcRenderer;
@@ -45,27 +45,8 @@ export const VoiceSettingsPage: PageComponent<VoiceSettingsProps> = () => {
       };
     }
   }, []);
-  const fetchMics = useCallback(() => {
-    navigator.mediaDevices.getUserMedia({ audio: true }).then(() => {
-      navigator.mediaDevices
-        ?.enumerateDevices()
-        .then((d) =>
-          setDevices(
-            d
-              .filter(
-                (device) => device.kind === "audioinput" && device.deviceId
-              )
-              .map((device) => ({ id: device.deviceId, label: device.label }))
-          )
-        );
-    });
-  }, []);
 
   const { t } = useTypeSafeTranslation();
-
-  useEffect(() => {
-    fetchMics();
-  }, [fetchMics]);
 
   return (
     <DefaultDesktopLayout>

--- a/kibbeh/src/shared-hooks/useDevices.ts
+++ b/kibbeh/src/shared-hooks/useDevices.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useCallback } from "react";
+
+export const useDevices = () => {
+  const [devices, setDevices] = useState<Array<{ id: string; label: string }>>(
+    []
+  );
+
+  const fetchMics = useCallback(() => {
+    navigator.mediaDevices.getUserMedia({ audio: true }).then(() => {
+      navigator.mediaDevices
+        ?.enumerateDevices()
+        .then((d) =>
+          setDevices(
+            d
+              .filter(
+                (device) => device.kind === "audioinput" && device.deviceId
+              )
+              .map((device) => ({ id: device.deviceId, label: device.label }))
+          )
+        );
+    });
+  }, []);
+
+  useEffect(() => {
+    fetchMics();
+  }, [fetchMics]);
+
+  return {
+    devices,
+    fetchMics,
+  };
+};

--- a/kibbeh/src/ui/RoomPanelIconBar.tsx
+++ b/kibbeh/src/ui/RoomPanelIconBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   SolidCompass,
   SolidFriends,
@@ -12,7 +12,6 @@ import { useScreenType } from "../shared-hooks/useScreenType";
 import { useTypeSafeTranslation } from "../shared-hooks/useTypeSafeTranslation";
 import { BoxedIcon } from "./BoxedIcon";
 import { Button } from "./Button";
-import { ErrorToast } from "./ErrorToast";
 
 interface RoomPanelIconBarProps {
   mute?: {

--- a/kibbeh/src/ui/RoomPanelIconBar.tsx
+++ b/kibbeh/src/ui/RoomPanelIconBar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import {
   SolidCompass,
   SolidFriends,
@@ -6,10 +6,13 @@ import {
   SolidMicrophoneOff,
   SolidSettings,
 } from "../icons";
+import { showErrorToast } from "../lib/showErrorToast";
+import { useDevices } from "../shared-hooks/useDevices";
 import { useScreenType } from "../shared-hooks/useScreenType";
 import { useTypeSafeTranslation } from "../shared-hooks/useTypeSafeTranslation";
 import { BoxedIcon } from "./BoxedIcon";
 import { Button } from "./Button";
+import { ErrorToast } from "./ErrorToast";
 
 interface RoomPanelIconBarProps {
   mute?: {
@@ -31,6 +34,18 @@ export const RoomPanelIconBar: React.FC<RoomPanelIconBarProps> = ({
 }) => {
   const { t } = useTypeSafeTranslation();
   const screenType = useScreenType();
+  const { devices } = useDevices();
+
+  useEffect(() => {
+    if (devices.length === 0) {
+      showErrorToast(t("pages.voiceSettings.permissionError"));
+    }
+  }, [devices.length, t]);
+
+  // {devices.length === 0 && (
+  //   <ErrorToast message={t("pages.voiceSettings.permissionError")} />
+  // )}
+
   return (
     <div className="justify-between bg-primary-700 rounded-b-8 py-3 px-4 w-full">
       <div>
@@ -81,7 +96,6 @@ export const RoomPanelIconBar: React.FC<RoomPanelIconBarProps> = ({
           </BoxedIcon>
         ) : null}
       </div>
-
       <Button
         transition
         className={`ml-2`}

--- a/kibbeh/src/ui/RoomPanelIconBar.tsx
+++ b/kibbeh/src/ui/RoomPanelIconBar.tsx
@@ -42,10 +42,6 @@ export const RoomPanelIconBar: React.FC<RoomPanelIconBarProps> = ({
     }
   }, [devices.length, t]);
 
-  // {devices.length === 0 && (
-  //   <ErrorToast message={t("pages.voiceSettings.permissionError")} />
-  // )}
-
   return (
     <div className="justify-between bg-primary-700 rounded-b-8 py-3 px-4 w-full">
       <div>
@@ -96,6 +92,7 @@ export const RoomPanelIconBar: React.FC<RoomPanelIconBarProps> = ({
           </BoxedIcon>
         ) : null}
       </div>
+
       <Button
         transition
         className={`ml-2`}

--- a/kibbeh/src/ui/RoomPanelIconBar.tsx
+++ b/kibbeh/src/ui/RoomPanelIconBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import {
   SolidCompass,
   SolidFriends,
@@ -33,13 +33,6 @@ export const RoomPanelIconBar: React.FC<RoomPanelIconBarProps> = ({
 }) => {
   const { t } = useTypeSafeTranslation();
   const screenType = useScreenType();
-  const { devices } = useDevices();
-
-  useEffect(() => {
-    if (devices.length === 0) {
-      showErrorToast(t("pages.voiceSettings.permissionError"));
-    }
-  }, [devices.length, t]);
 
   return (
     <div className="justify-between bg-primary-700 rounded-b-8 py-3 px-4 w-full">

--- a/kibbeh/src/ui/RoomPanelIconBar.tsx
+++ b/kibbeh/src/ui/RoomPanelIconBar.tsx
@@ -6,8 +6,6 @@ import {
   SolidMicrophoneOff,
   SolidSettings,
 } from "../icons";
-import { showErrorToast } from "../lib/showErrorToast";
-import { useDevices } from "../shared-hooks/useDevices";
 import { useScreenType } from "../shared-hooks/useScreenType";
 import { useTypeSafeTranslation } from "../shared-hooks/useTypeSafeTranslation";
 import { BoxedIcon } from "./BoxedIcon";
@@ -33,7 +31,6 @@ export const RoomPanelIconBar: React.FC<RoomPanelIconBarProps> = ({
 }) => {
   const { t } = useTypeSafeTranslation();
   const screenType = useScreenType();
-
   return (
     <div className="justify-between bg-primary-700 rounded-b-8 py-3 px-4 w-full">
       <div>


### PR DESCRIPTION
When the user joins a room, if mic access not been granted, a toast will pop up letting you know. Created a new shared hook which lists the current microphone devices which we have permissions to use.
![micperm](https://user-images.githubusercontent.com/9464690/114598718-e4a75400-9c9a-11eb-81e7-3887c8f048c2.png)

Resolves #1927 