### PR TITLE
fix(roomchatinput): clear chat input when leaving room

### DIFF
--- a/kibbeh/src/modules/room/chat/RoomChatInput.tsx
+++ b/kibbeh/src/modules/room/chat/RoomChatInput.tsx
@@ -48,6 +48,10 @@ export const RoomChatInput: React.FC<ChatInputProps> = ({ users }) => {
     if (!open) inputRef.current?.focus();
   }, [open]);
 
+  useEffect(() => () => {
+    setMessage("");
+  }, []);
+
   const handleSubmit = (
     e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement>
   ) => {


### PR DESCRIPTION
prevent chat input from leaking to other rooms by clearing the input when user leaves current room

**fix** #2000

This is a fix for the referenced issue above. Currently when you leave a room while typing a message, the message remains persisted when you join another room.

By adding a hook to clear the input when `RoomChatInput` component unmounts, the issue is fixed.