### PR TITLE
docs(baklava): add post-install docs for the snapped version of DogeHouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,23 +57,46 @@ Please read [CONTRIBUTING.md](https://github.com/benawad/dogehouse/blob/staging/
 
 ## DogeHouse Desktop
 
-A desktop app built with [electron](https://www.electronjs.org/) is available for Windows, Mac, and Linux
+A desktop app built with [Electron](https://www.electronjs.org/) is available for Windows, Mac, and Linux.
 
 Download links are in [the releases section](https://github.com/benawad/dogehouse/releases/latest)
 
-Dogehouse is also available in the AUR
+Dogehouse is also available in the AUR...
 
 ```bash
 yay -S dogehouse
 ```
 
-And in an Ubuntu ppa
+...and in an Ubuntu PPA/self-hosted APT repoistory...
 
 ```bash
+# using the self-hosted APT repoistory
+# should work for most modern Debian-based repos
 echo "deb http://ppa.dogehouse.tv/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null
 wget -q -O - http://ppa.dogehouse.tv/KEY.gpg | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install dogehouse
+
+# using the PPA from Launchpad.net
+# SOON
+```
+
+...and of course, as an snap for systemd-supported Linux distros. ([Don't have `snapd` Get set up for snaps first.](https://snapcraft.io/docs/installing-snapd))
+
+```sh
+# currently, only the edge channel is available for download
+# when reached desktop client stability, it will be installed from the stable channel.
+# for daily builds, add --edge.
+sudo snap install dogehouse
+
+# after installing, connect the audio-reord interface in orfer to
+# have mic access for rooms
+sudo snap connect dogehouse:audio-record
+
+# then launch the app from either the GUI or terminal
+# first-launch may take a bit longer because the `.snap` file needs to be
+# unsquashed first before using
+dogehouse
 ```
 
 **_Notes:_**

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ sudo apt-get install dogehouse
 # SOON
 ```
 
-...and of course, as an snap for systemd-supported Linux distros. ([Don't have `snapd` Get set up for snaps first.](https://snapcraft.io/docs/installing-snapd))
+...and of course, as an snap for systemd-supported Linux distros. ([Don't have `snapd`? Get set up for snaps first.](https://snapcraft.io/docs/installing-snapd))
 
 ```sh
 # currently, only the edge channel is available for download

--- a/README.md
+++ b/README.md
@@ -59,49 +59,31 @@ Please read [CONTRIBUTING.md](https://github.com/benawad/dogehouse/blob/staging/
 
 A desktop app built with [Electron](https://www.electronjs.org/) is available for Windows, Mac, and Linux.
 
-Download links are in [the releases section](https://github.com/benawad/dogehouse/releases/latest)
+There are different ways to get the Electron desktop app:
 
-Dogehouse is also available in the AUR...
+* Get the official builds from [here, in GitHub Releases][gh-releases]
+for any platform.
+* Get it from AUR for Arch/Manjaro with `yay -S dogehouse`.
+* Get the desktop client for Debian-based distros (including Ubuntu)
+from the official APT repo with these simple steps:
+  * Add the repo with `echo "deb http://ppa.dogehouse.tv/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null`
+  * Add Ben Awad's GPG key with `$(command -v curl>>/dev/null && echo "curl -o-" || echo "wget -q0-") http://ppa.dogehouse.tv/KEY.gpg | sudo apt-key add -`.
+  * Finally, update your local repoistory list and install DogeHouse
+with `sudo apt update && sudo apt install dogehouse`.
+* Get the snap for your systemd-powered Linux distro from either the
+[Snap Store](https://snapcraft.io/dogehouse) or in an terminal with
+`sudo snap install dogehouse`.
+  * After installing the snap, you need to allow microphone access with
+`sudo snap connect dogehouse:audio-record` to be able to speak in rooms.
 
-```bash
-yay -S dogehouse
-```
-
-...and in an Ubuntu PPA/self-hosted APT repoistory...
-
-```bash
-# using the self-hosted APT repoistory
-# should work for most modern Debian-based repos
-echo "deb http://ppa.dogehouse.tv/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null
-wget -q -O - http://ppa.dogehouse.tv/KEY.gpg | sudo apt-key add -
-sudo apt-get update
-sudo apt-get install dogehouse
-
-# using the PPA from Launchpad.net
-# SOON
-```
-
-...and of course, as an snap for systemd-supported Linux distros. ([Don't have `snapd`? Get set up for snaps first.](https://snapcraft.io/docs/installing-snapd))
-
-```sh
-# currently, only the edge channel is available for download
-# when reached desktop client stability, it will be installed from the stable channel.
-# for daily builds, add --edge.
-sudo snap install dogehouse
-
-# after installing, connect the audio-reord interface in orfer to
-# have mic access for rooms
-sudo snap connect dogehouse:audio-record
-
-# then launch the app from either the GUI or terminal
-# first-launch may take a bit longer because the `.snap` file needs to be
-# unsquashed first before using
-dogehouse
-```
+[gh-releases]: https://github.com/benawad/dogehouse/releases
 
 **_Notes:_**
 
 - If a warning message pops up on Windows, go to 'more info' and select 'Run Anyway'
+- Currently, the snap package's available channels are only `edge` as
+contributions for Baklava are merged almost on daily basis. Tested
+versions that are stable will be promoted into `stable` in the future.
 
 ## DogeReviewers
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A desktop app built with [Electron](https://www.electronjs.org/) is available fo
 
 There are different ways to get the Electron desktop app:
 
-* Get the official builds from [here, in GitHub Releases][gh-releases/latest]
+* Get the official builds from [here, in GitHub Releases][gh-releases]
 for any platform.
 * Get it from AUR (unofficial package) for Arch/Manjaro with
 `yay -S dogehouse`.
@@ -77,7 +77,7 @@ with `sudo apt update && sudo apt install dogehouse`.
   * After installing the snap, you need to allow microphone access with
 `sudo snap connect dogehouse:audio-record` to be able to speak in rooms.
 
-[gh-releases]: https://github.com/benawad/dogehouse/releases
+[gh-releases]: https://github.com/benawad/dogehouse/releases/latest
 
 **_Notes:_**
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A desktop app built with [Electron](https://www.electronjs.org/) is available fo
 
 There are different ways to get the Electron desktop app:
 
-* Get the official builds from [here, in GitHub Releases][gh-releases]
+* Get the official builds from [here, in GitHub Releases][gh-releases/latest]
 for any platform.
 * Get it from AUR (unofficial package) for Arch/Manjaro with
 `yay -S dogehouse`.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ There are different ways to get the Electron desktop app:
 
 * Get the official builds from [here, in GitHub Releases][gh-releases]
 for any platform.
-* Get it from AUR for Arch/Manjaro with `yay -S dogehouse`.
+* Get it from AUR (unofficial package) for Arch/Manjaro with
+`yay -S dogehouse`.
 * Get the desktop client for Debian-based distros (including Ubuntu)
-from the official APT repo with these simple steps:
+from the unofficial APT repo with these simple steps:
   * Add the repo with `echo "deb http://ppa.dogehouse.tv/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null`
   * Add Ben Awad's GPG key with `$(command -v curl>>/dev/null && echo "curl -o-" || echo "wget -q0-") http://ppa.dogehouse.tv/KEY.gpg | sudo apt-key add -`.
   * Finally, update your local repoistory list and install DogeHouse

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ for any platform.
 * Get it from AUR (unofficial package) for Arch/Manjaro with
 `yay -S dogehouse`.
 * Get the desktop client for Debian-based distros (including Ubuntu)
-from the unofficial APT repo with these simple steps:
+from the official APT repo with these simple steps:
   * Add the repo with `echo "deb http://ppa.dogehouse.tv/ ./" | sudo tee -a /etc/apt/sources.list > /dev/null`
   * Add Ben Awad's GPG key with `$(command -v curl>>/dev/null && echo "curl -o-" || echo "wget -q0-") http://ppa.dogehouse.tv/KEY.gpg | sudo apt-key add -`.
   * Finally, update your local repoistory list and install DogeHouse

--- a/baklava/README.md
+++ b/baklava/README.md
@@ -11,14 +11,18 @@ It uses ElectronJS as a wrapper for [dogehouse.tv](https://dogehouse.tv) and add
 - Splash screen
 - Localization
 
-## How to run
+## Installing from releases
+
+See the [root README](../README.md) for details.
+
+## How to reproduce builds
 
 > NOTE: Windows users may have to install Visual Studio 2019 and the workload `Desktop Development with C++`.
 
-- Run `yarn install`
+- Run `yarn install` to install Node.js dependencies for the Electron app.
 - Ensure [Rust](https://www.rust-lang.org/learn/get-started) is installed
 - Install `nj-cli` by running `cargo install nj-cli`
-- Run `yarn build:globkey`
+- Run `yarn build:globkey` to build the global keys.
 - Run `yarn start`
 - *(Optional)* Run `yarn build:%YOUR_PLATFORM_CODE%` and install the app from the build *(located in `/builds`)*
 

--- a/baklava/README.md
+++ b/baklava/README.md
@@ -11,10 +11,6 @@ It uses ElectronJS as a wrapper for [dogehouse.tv](https://dogehouse.tv) and add
 - Splash screen
 - Localization
 
-## Installing from releases
-
-See the [root README](../README.md) for details.
-
 ## How to reproduce builds
 
 > NOTE: Windows users may have to install Visual Studio 2019 and the workload `Desktop Development with C++`.

--- a/baklava/README.md
+++ b/baklava/README.md
@@ -11,7 +11,7 @@ It uses ElectronJS as a wrapper for [dogehouse.tv](https://dogehouse.tv) and add
 - Splash screen
 - Localization
 
-## How to reproduce builds
+## How to run
 
 > NOTE: Windows users may have to install Visual Studio 2019 and the workload `Desktop Development with C++`.
 

--- a/baklava/README.md
+++ b/baklava/README.md
@@ -15,10 +15,10 @@ It uses ElectronJS as a wrapper for [dogehouse.tv](https://dogehouse.tv) and add
 
 > NOTE: Windows users may have to install Visual Studio 2019 and the workload `Desktop Development with C++`.
 
-- Run `yarn install` to install Node.js dependencies for the Electron app.
+- Run `yarn install`
 - Ensure [Rust](https://www.rust-lang.org/learn/get-started) is installed
 - Install `nj-cli` by running `cargo install nj-cli`
-- Run `yarn build:globkey` to build the global keys.
+- Run `yarn build:globkey`
 - Run `yarn start`
 - *(Optional)* Run `yarn build:%YOUR_PLATFORM_CODE%` and install the app from the build *(located in `/builds`)*
 


### PR DESCRIPTION
Follow-up of https://github.com/benawad/dogehouse/pull/1947, regarding about `audio-record` snap interface aren't autoconnected on install as per [the docs](https://snapcraft.io/docs/supported-interfaces). Also, I updated the install docs for the desktop client app and add some sprinkles into `baklava/README.md`.

Also I'll plan to host an PPA also in [Launchpad](https://launchpad.net/~madebythepinshub/+archive/ubuntu/dogehouse-electron) but I'll also automate it soon.