### PR TITLE
Attempt at forcing an update of the favicon

### DIFF
--- a/kibbeh/src/pages/_app.tsx
+++ b/kibbeh/src/pages/_app.tsx
@@ -67,7 +67,7 @@ function App({ Component, pageProps }: AppProps) {
       <QueryClientProvider client={queryClient}>
         <MainWsHandlerProvider>
           <Head>
-            <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
+            <link rel="icon" href="/favicon.ico" type="image/x-icon" />
             <meta
               name="viewport"
               content="width=device-width, initial-scale=1, user-scalable=no, user-scalable=0"

--- a/kibbeh/src/pages/_app.tsx
+++ b/kibbeh/src/pages/_app.tsx
@@ -67,6 +67,7 @@ function App({ Component, pageProps }: AppProps) {
       <QueryClientProvider client={queryClient}>
         <MainWsHandlerProvider>
           <Head>
+            <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
             <meta
               name="viewport"
               content="width=device-width, initial-scale=1, user-scalable=no, user-scalable=0"


### PR DESCRIPTION
This PR attempts at forcing the new logo for our favicon. currently the old (cached) one is shown at [dogehouse.tv](https://dogehouse.tv).


<sub>Kofta is dead, long live Kibbeh 🐕🏠🚀🌕</sub>