### PR TITLE
Link regex updated

### DIFF
--- a/kibbeh/src/lib/constants.ts
+++ b/kibbeh/src/lib/constants.ts
@@ -3,5 +3,5 @@ export const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL!;
 export const baseUrl = process.env.NEXT_PUBLIC_BASE_URL!;
 export const loginNextPathKey = "@dogehouse/login-next";
 
-export const linkRegex = /(https?:\/\/)(www\.)?([-a-z0-9]{1,63}\.)*?[a-z0-9][-a-z0-9]{0,61}[a-z0-9]\.[a-z]{1,6}(\/[-\\w@\\+\\.~#\\?&/=%]*)?[^\s()]+/;
+export const linkRegex = /\s(https?:\/\/)(www\.)?([-a-z0-9]{1,63}\.)*?[a-z0-9][-a-z0-9]{0,61}[a-z0-9]\.[a-z]{1,6}(\/[-\\w@\\+\\.~#\\?&/=%]*)?[^\s()]+/;
 export const codeBlockRegex = /`([^`]*)`/g;

--- a/kibbeh/src/lib/constants.ts
+++ b/kibbeh/src/lib/constants.ts
@@ -3,5 +3,5 @@ export const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL!;
 export const baseUrl = process.env.NEXT_PUBLIC_BASE_URL!;
 export const loginNextPathKey = "@dogehouse/login-next";
 
-export const linkRegex = /(https?:\/\/)(www\.)?([-a-z0-9]{1,63}\.)*?[a-z0-9][-a-z0-9]{0,61}[a-z0-9]\.[a-z]{1,6}(\/[-\\w@\\+\\.~#\\?&/=%]*)?[^\s()]+/;
+export const linkRegex = /(^|\s)(https?:\/\/)(www\.)?([-a-z0-9]{1,63}\.)*?[a-z0-9][-a-z0-9]{0,61}[a-z0-9]\.[a-z]{1,6}(\/[-\\w@\\+\\.~#\\?&/=%]*)?[^\s()]+/;
 export const codeBlockRegex = /`([^`]*)`/g;

--- a/kibbeh/src/lib/tests/constants.test.ts
+++ b/kibbeh/src/lib/tests/constants.test.ts
@@ -1,25 +1,25 @@
 import { linkRegex } from "../constants";
 
 describe("Link Regex", () => {
-  test("Link Regex Test 1(Only Link)", () => {
+  test("Only Link", () => {
     const msg1 = "https://abc.com";
 
     expect(linkRegex.test(msg1)).toBeTruthy();
   });
 
-  test("Link Regex Test 2(Link between text)", () => {
+  test("Link between text", () => {
     const msg2 = "some text https://abc.com other text";
 
     expect(linkRegex.test(msg2)).toBeTruthy();
   });
 
-  test("Link Regex Test 3(Link in brackets)", () => {
+  test("Link in brackets", () => {
     const msg3 = "(https://abc.com)";
 
     expect(linkRegex.test(msg3)).toBeFalsy();
   });
 
-  test("Link Regex Test 4(Link with parameters)", () => {
+  test("Link with parameters", () => {
     const msg4 = "text after https://abc.com/queries?parameter text after";
 
     expect(linkRegex.test(msg4)).toBeTruthy();

--- a/kibbeh/src/lib/tests/constants.test.ts
+++ b/kibbeh/src/lib/tests/constants.test.ts
@@ -1,0 +1,25 @@
+import { linkRegex } from "../constants";
+
+test("Link Regex Test 1(Only Link)", () => {
+  const msg1 = "https://abc.com";
+
+  expect(linkRegex.test(msg1)).toBeTruthy();
+});
+
+test("Link Regex Test 2(Link between text)", () => {
+  const msg2 = "some text https://abc.com other text";
+
+  expect(linkRegex.test(msg2)).toBeTruthy();
+});
+
+test("Link Regex Test 3(Link in brackets)", () => {
+  const msg3 = "(https://abc.com)";
+
+  expect(linkRegex.test(msg3)).toBeFalsy();
+});
+
+test("Link Regex Test 4(Link with parameters)", () => {
+  const msg4 = "text after https://abc.com/queries?parameter text after";
+
+  expect(linkRegex.test(msg4)).toBeTruthy();
+});

--- a/kibbeh/src/lib/tests/constants.test.ts
+++ b/kibbeh/src/lib/tests/constants.test.ts
@@ -1,25 +1,27 @@
 import { linkRegex } from "../constants";
 
-test("Link Regex Test 1(Only Link)", () => {
-  const msg1 = "https://abc.com";
+describe("Link Regex", () => {
+  test("Link Regex Test 1(Only Link)", () => {
+    const msg1 = "https://abc.com";
 
-  expect(linkRegex.test(msg1)).toBeTruthy();
-});
+    expect(linkRegex.test(msg1)).toBeTruthy();
+  });
 
-test("Link Regex Test 2(Link between text)", () => {
-  const msg2 = "some text https://abc.com other text";
+  test("Link Regex Test 2(Link between text)", () => {
+    const msg2 = "some text https://abc.com other text";
 
-  expect(linkRegex.test(msg2)).toBeTruthy();
-});
+    expect(linkRegex.test(msg2)).toBeTruthy();
+  });
 
-test("Link Regex Test 3(Link in brackets)", () => {
-  const msg3 = "(https://abc.com)";
+  test("Link Regex Test 3(Link in brackets)", () => {
+    const msg3 = "(https://abc.com)";
 
-  expect(linkRegex.test(msg3)).toBeFalsy();
-});
+    expect(linkRegex.test(msg3)).toBeFalsy();
+  });
 
-test("Link Regex Test 4(Link with parameters)", () => {
-  const msg4 = "text after https://abc.com/queries?parameter text after";
+  test("Link Regex Test 4(Link with parameters)", () => {
+    const msg4 = "text after https://abc.com/queries?parameter text after";
 
-  expect(linkRegex.test(msg4)).toBeTruthy();
+    expect(linkRegex.test(msg4)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
### Description
I updated the link regex to check for space before the actual URL to prevent invalid URLs. 

### Related issue
[#2047 ](https://github.com/benawad/dogehouse/issues/2047) 

### Screenshots
#### Before:
![Screenshot (9)](https://user-images.githubusercontent.com/63552235/115038468-321aff80-9eed-11eb-81ba-8af46e4eae72.png)
#### After:
![Screenshot (8)](https://user-images.githubusercontent.com/63552235/115038581-4ced7400-9eed-11eb-8b18-04d571c53349.png)
