### PR TITLE
fix(auth redirect): user is now redirected to previously requested page after login

### DIFF
--- a/kibbeh/src/modules/auth/useVerifyLoggedIn.ts
+++ b/kibbeh/src/modules/auth/useVerifyLoggedIn.ts
@@ -3,14 +3,19 @@ import { useEffect } from "react";
 import { useTokenStore } from "./useTokenStore";
 
 export const useVerifyLoggedIn = () => {
-  const { replace, pathname } = useRouter();
+  const { replace, query, pathname } = useRouter();
+  const { id } = query;
   const hasTokens = useTokenStore((s) => !!(s.accessToken && s.refreshToken));
 
   useEffect(() => {
     if (!hasTokens) {
-      replace(`/?next=${pathname}`);
+      if (id) {
+        replace(`/?next=/room/${id}`);
+      } else {
+        replace(pathname);
+      }
     }
-  }, [hasTokens, pathname, replace]);
+  }, [hasTokens, id, replace, pathname]);
 
   return hasTokens;
 };

--- a/kibbeh/src/modules/landing-page/LoginPage.tsx
+++ b/kibbeh/src/modules/landing-page/LoginPage.tsx
@@ -35,7 +35,7 @@ const LoginButton: React.FC<LoginButtonProps> = ({
     if (typeof query.next === "string" && query.next) {
       try {
         localStorage.setItem(loginNextPathKey, query.next);
-      } catch {}
+      } catch { }
     }
 
     window.location.href = oauthUrl as string;
@@ -65,7 +65,7 @@ export const LoginPage: React.FC = () => {
   useSaveTokensFromQueryParams();
   const hasTokens = useTokenStore((s) => !!(s.accessToken && s.refreshToken));
   const { setConn } = useContext(WebSocketContext);
-  const { push } = useRouter();
+  const { push, query } = useRouter();
 
   useEffect(() => {
     // only want this on mount
@@ -75,9 +75,13 @@ export const LoginPage: React.FC = () => {
 
   useEffect(() => {
     if (hasTokens) {
-      push("/dash");
+      if (query.next) {
+        push(query.next);
+      } else {
+        push('/dash');
+      }
     }
-  }, [hasTokens, push]);
+  }, [hasTokens, push, query]);
 
   return (
     <>


### PR DESCRIPTION
fix #2107

This PR stops the "?next=" parameter in the address bar of the login screen being "/room/[id]" after trying to access a room while not being logged in and instead populates it with the correct requested page and redirects the user there after login.

I've tested on my machine with local accounts, but couldn't get logged in using OAuth - so please do test this using steps from #2107 before accepting this PR. 

Thanks!