### PR TITLE
Fixes #2124 - Don't join user room when profile clicked on sidebar

### DIFF
--- a/kibbeh/src/modules/layouts/TabletSidebar.tsx
+++ b/kibbeh/src/modules/layouts/TabletSidebar.tsx
@@ -30,14 +30,7 @@ const Page: React.FC<{
     <>
       {data?.users.map((u) => (
         <div key={u.id} className="flex pb-3 w-full justify-center">
-          <ApiPreloadLink
-            {...(u.currentRoom
-              ? { route: "room", data: { id: u.currentRoom.id } }
-              : {
-                  route: "profile",
-                  data: { username: u.username },
-                })}
-          >
+          <ApiPreloadLink route="profile" data={{ username: u.username }}>
             <SingleUser
               size="sm"
               isOnline={u.online}


### PR DESCRIPTION
In the tablet view, clicking on a user's avatar would join their room if they have one. This PR changes so that you only ever open their profile. 

I'm not sure why this check was done in the first place, or if there is some use case I'm missing. Maybe it should only join the room on click if you're not already in a room.

Resolves #2124 
