### PR TITLE
locale/cs: Translate "Login with Discord"

### DIFF
--- a/kibbeh/public/locales/cs/translation.json
+++ b/kibbeh/public/locales/cs/translation.json
@@ -60,7 +60,7 @@
       "loginGithub": "Přihlásit se přes GitHub",
       "loginTwitter": "Přihlásit se přes Twitter",
       "createTestUser": "Vytvořit testovacího uživatele",
-      "loginDiscord": "Login with Discord"
+      "loginDiscord": "Přihlásit se přes Discord"
     },
     "myProfile": {
       "logout": "Odhlásit se",

--- a/kibbeh/public/locales/nl/translation.json
+++ b/kibbeh/public/locales/nl/translation.json
@@ -103,7 +103,10 @@
       "volume": "Volume:"
     },
     "overlaySettings": {
-      "input": { "errorMsg": "Ongeldige applicatietitel", "label": "Voer applicatietitel in" },
+      "input": {
+        "errorMsg": "Ongeldige applicatietitel",
+        "label": "Voer applicatietitel in"
+      },
       "header": "Overlay-instellingen"
     }
   },


### PR DESCRIPTION
I ran `yarn i18` and translated "Login with Discord"