### PR TITLE
Fixes #2137 - Hide empty room description & fix button outline

### DIFF
--- a/kibbeh/src/ui/RoomHeader.tsx
+++ b/kibbeh/src/ui/RoomHeader.tsx
@@ -19,18 +19,18 @@ export const RoomHeader: React.FC<RoomHeaderProps> = ({
     <div
       className={`flex flex-col p-4 bg-primary-800 rounded-t-8 border-b border-primary-600 w-full`}
     >
-      <div className={`flex text-primary-100`}>
+      <div className={`flex text-primary-100 mb-2`}>
         <button
           onClick={onTitleClick}
-          className={`flex text-xl font-bold mb-2 flex-1 truncate`}
+          className={`flex text-xl font-bold flex-1 truncate`}
         >
           {title}
         </button>
         {description.trim().length > 0 && (
-          <button className="pb-2" onClick={() => setOpen(!open)}>
+          <button className="flex" onClick={() => setOpen(!open)}>
             <SolidCaretRight
-              className={`ml-2 transform ${
-                open ? "-rotate-90" : "rotate-90"
+              className={`transform ${
+                open ? "-rotate-90 mt-auto" : "mr-auto rotate-90"
               } cursor-pointer`}
               width={20}
               height={20}

--- a/kibbeh/src/ui/RoomHeader.tsx
+++ b/kibbeh/src/ui/RoomHeader.tsx
@@ -26,15 +26,17 @@ export const RoomHeader: React.FC<RoomHeaderProps> = ({
         >
           {title}
         </button>
-        <button className="pb-2" onClick={() => setOpen(!open)}>
-          <SolidCaretRight
-            className={`ml-2 transform ${
-              open ? "-rotate-90" : "rotate-90"
-            } cursor-pointer`}
-            width={20}
-            height={20}
-          />
-        </button>
+        {description.trim().length > 0 && (
+          <button className="pb-2" onClick={() => setOpen(!open)}>
+            <SolidCaretRight
+              className={`ml-2 transform ${
+                open ? "-rotate-90" : "rotate-90"
+              } cursor-pointer`}
+              width={20}
+              height={20}
+            />
+          </button>
+        )}
       </div>
       <div className={`flex text-primary-200 text-sm`}>
         with{" "}


### PR DESCRIPTION
If a room has no description, no button will be rendered.

I also fixed the strange outline around the button caused from margin/paddings.

Before:
![before](https://user-images.githubusercontent.com/9464690/115237743-945e4500-a125-11eb-98fa-02316c3f1be3.gif)

After:
![oivXriR2T6](https://user-images.githubusercontent.com/9464690/115237750-97f1cc00-a125-11eb-9936-963565c45a32.gif)

Resolves #2137 
