### PR TITLE
fix(languageselector): fix SVG rotation on Safari

### DIFF
--- a/kibbeh/src/ui/LanguageSelector.tsx
+++ b/kibbeh/src/ui/LanguageSelector.tsx
@@ -109,7 +109,7 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
             className="absolute left-3 text-primary-100 top-1/2 transform translate-y-n1/2 py-1 focus:outline-no-chrome hover:bg-primary-700 z-30 rounded-5"
             style={{ paddingLeft: "10px", paddingRight: "-6px" }}
           >
-            {backIcon({ transform: "rotate(-180)" })}
+            {backIcon({ style: { "transform": "rotate(180deg)" } })}
           </button>
           <p className="block relative text-center top-1/2 transform translate-y-n1/2 w-full font-semibold text-primary-100">
             Language


### PR DESCRIPTION
Change to CSS transform as Safari doesn't support SVG transform attribute.