### PR TITLE
feat(kibbeh): In the EditProfileModal, make the bio textarea resizable

### DIFF
--- a/kibbeh/src/modules/user/EditProfileModal.tsx
+++ b/kibbeh/src/modules/user/EditProfileModal.tsx
@@ -131,7 +131,7 @@ export const EditProfileModal: React.FC<EditProfileModalProps> = ({
                 name="username"
               />
               <InputField
-                className={`mb-4`}
+                className={`mb-4 resizable-textarea`}
                 errorMsg={t("components.modals.editProfileModal.bioError")}
                 label={t("components.modals.editProfileModal.bioLabel")}
                 textarea

--- a/kibbeh/src/styles/globals.css
+++ b/kibbeh/src/styles/globals.css
@@ -106,7 +106,7 @@ html {
   overflow: auto;
 }
 
-textarea {
+textarea :not(.resizable-textarea) {
   resize: none;
 }
 


### PR DESCRIPTION
The `textarea` is too small for the user's bio. It can only accommodate 2 lines by default. Making it resizable should be more convenient. 