### PR TITLE
docs(DogeBook): scrolling through the docs page now works

### DIFF
--- a/kibbeh/.storybook/manager.js
+++ b/kibbeh/.storybook/manager.js
@@ -2,8 +2,8 @@ import { addons } from "@storybook/addons";
 import { create } from "@storybook/theming";
 
 addons.setConfig({
-    theme: create({
-        base: "dark",
-        brandTitle: "DogeBook",
-    }),
+  theme: create({
+    base: "dark",
+    brandTitle: "DogeBook",
+  }),
 });

--- a/kibbeh/.storybook/preview-head.html
+++ b/kibbeh/.storybook/preview-head.html
@@ -1,0 +1,16 @@
+<div id="docs-root"></div>
+
+<style>
+  .sbdocs.sbdocs-wrapper.css-zgt7u1 {
+    overflow-y: scroll;
+    display: flex;
+    -webkit-box-pack: center;
+    flex: 1 1 auto;
+    justify-content: center;
+    padding: 4rem 20px;
+    -webkit-text-emphasis-position: over;
+    ight: 100vh;
+    height: 100vh;
+    box-sizing: border-box;
+  }
+</style>


### PR DESCRIPTION
This PR:
- Allows users to scroll through the docs page
- This allows us to view our components definitions and types

Screenshot of Before: 
![before-doc-fix](https://user-images.githubusercontent.com/5723692/115440775-f8841600-a1c4-11eb-8631-d2ffad864f15.png)

Now After (GIF):
![docs-fix-after](https://user-images.githubusercontent.com/5723692/115440942-2701f100-a1c5-11eb-86c1-aacb2f764392.gif)

