### PR TITLE
Fix Electron Scroll Bug

### DIFF
--- a/kibbeh/src/pages/_app.tsx
+++ b/kibbeh/src/pages/_app.tsx
@@ -52,6 +52,10 @@ function App({ Component, pageProps }: AppProps) {
           useHostStore.getState().setData(platform);
         }
       );
+      document.documentElement.style.setProperty(
+        "--screen-height-reduction",
+        "30px"
+      );
     }
   }, []);
 

--- a/kibbeh/src/styles/globals.css
+++ b/kibbeh/src/styles/globals.css
@@ -35,6 +35,8 @@ p.bold {
   --color-accent: #fd4d4d;
   --color-accent-hover: #fd6868;
   --color-accent-disabled: #f5bfbf;
+
+  --screen-height-reduction: 0px;
 }
 
 h1 {
@@ -120,4 +122,8 @@ img.emoji {
   width: 1em;
   margin: 0 0.05em 0 0.1em;
   vertical-align: -0.1em;
+}
+
+.h-screen {
+  height: calc(100vh - var(--screen-height-reduction));
 }


### PR DESCRIPTION
## Fixed
This is a simple change which fixes the electron scroll bug. 

## Description of what Changed
It overwrites the `.h-screen` class in the global css file. It sets the height of the class to the screen height minus the title bar height via the calc function. It uses the `--screen-height-reduction` variable as the amount to subtract which is `0px` by default. Then, in `_app.tsx`, if electron is present, the variable  `--screen-height-reduction` is set to `30px`, which is the height of the top bar. This then gets subtracted from the total view height because electron sees the bar as part of the view height. This essentially just tells it to set the view height to the total minus the bar if it is running in electron. 

If you would like any changes made or anything else like that, please tell me and I would be happy to do so. Thanks!

## Closes
- Closes #2027 