### PR TITLE
#2281 Fix number formatter

### DIFF
--- a/kibbeh/src/lib/kFormatter.ts
+++ b/kibbeh/src/lib/kFormatter.ts
@@ -1,15 +1,10 @@
-export const kFormatter = (num: number) => {
-  if (Math.abs(num) > 999999999) {
-    return `${
-      Math.sign(num) * Number((Math.abs(num) / 1000000000).toFixed(1))
-    }b`;
-  }
-  if (Math.abs(num) > 999999) {
-    return `${Math.sign(num) * Number((Math.abs(num) / 1000000).toFixed(1))}m`;
-  }
-  if (Math.abs(num) > 999) {
-    return `${Math.sign(num) * Number((Math.abs(num) / 1000).toFixed(1))}k`;
+export const kFormatter = (n: number) => {
+  if (n < 1000) {
+    return `${n}`;
   }
 
-  return Math.sign(num) * Math.abs(num);
+  const base = Math.floor(Math.log(Math.abs(n)) / Math.log(1000));
+  const suffix = "kmb"[base - 1];
+  const abbrev = String(n / 1000 ** base).substring(0, 3);
+  return (abbrev.endsWith(".") ? abbrev.slice(0, -1) : abbrev) + suffix;
 };

--- a/kibbeh/src/lib/kFormatter.ts
+++ b/kibbeh/src/lib/kFormatter.ts
@@ -1,10 +1,10 @@
-export const kFormatter = (n: number) => {
-  if (n < 1000) {
-    return `${n}`;
+export const kFormatter = (num: number) => {
+  if (num < 1000) {
+    return `${num}`;
   }
 
-  const base = Math.floor(Math.log(Math.abs(n)) / Math.log(1000));
+  const base = Math.floor(Math.log(Math.abs(num)) / Math.log(1000));
   const suffix = "kmb"[base - 1];
-  const abbrev = String(n / 1000 ** base).substring(0, 3);
+  const abbrev = String(num / 1000 ** base).substring(0, 3);
   return (abbrev.endsWith(".") ? abbrev.slice(0, -1) : abbrev) + suffix;
 };

--- a/kibbeh/src/lib/tests/kFormatter.test.ts
+++ b/kibbeh/src/lib/tests/kFormatter.test.ts
@@ -4,4 +4,24 @@ describe("Number formatter", () => {
   it("should return 1", () => {
     expect(kFormatter(1)).toBe("1");
   });
+
+  it("should return 1k", () => {
+    expect(kFormatter(1000)).toBe("1k");
+  });
+
+  it("should return 3.8k", () => {
+    expect(kFormatter(3821)).toBe("3.8k");
+  });
+
+  it("should return 9.9k", () => {
+    expect(kFormatter(9999)).toBe("9.9k");
+  });
+
+  it("should return 10k", () => {
+    expect(kFormatter(10500)).toBe("10k");
+  });
+
+  it("should return 101k", () => {
+    expect(kFormatter(101800)).toBe("101k");
+  });
 });

--- a/kibbeh/src/lib/tests/kFormatter.test.ts
+++ b/kibbeh/src/lib/tests/kFormatter.test.ts
@@ -1,0 +1,7 @@
+import { kFormatter } from "../kFormatter";
+
+describe("Number formatter", () => {
+  it("should return 1", () => {
+    expect(kFormatter(1)).toBe("1");
+  });
+});

--- a/kibbeh/src/lib/tests/kFormatter.test.ts
+++ b/kibbeh/src/lib/tests/kFormatter.test.ts
@@ -24,4 +24,24 @@ describe("Number formatter", () => {
   it("should return 101k", () => {
     expect(kFormatter(101800)).toBe("101k");
   });
+
+  it("should return 3m", () => {
+    expect(kFormatter(3000000)).toBe("3m");
+  });
+
+  it("should return 3.8m", () => {
+    expect(kFormatter(3800000)).toBe("3.8m");
+  });
+
+  it("should return 98m", () => {
+    expect(kFormatter(98150000)).toBe("98m");
+  });
+
+  it("should return 124m", () => {
+    expect(kFormatter(124200000)).toBe("124m");
+  });
+
+  it("should return 9.9m", () => {
+    expect(kFormatter(9999999)).toBe("9.9m");
+  });
 });


### PR DESCRIPTION
Number formatter will no longer round up. So "9999" won't show "10k".

Added test cases for each.

Resolves #2281 