### PR TITLE
Match Figma Design (User Profile)

### DIFF
--- a/kibbeh/src/ui/ProfileAbout.tsx
+++ b/kibbeh/src/ui/ProfileAbout.tsx
@@ -55,9 +55,9 @@ export const ProfileAbout: React.FC<ProfileAboutProps> = ({
           </ApiPreloadLink>
         </div>
       </div>
-      <p className="text-primary-100 text-sm pb-2 whitespace-pre-wrap max-h-5l truncate">
+      <div className="text-primary-100 pb-2 whitespace-pre-wrap max-h-5l truncate">
         {description}
-      </p>
+      </div>
       {link && (
         <div className="flex flex-row items-center mb-4">
           <SolidLink className="mr-2" />

--- a/kibbeh/src/ui/ProfileTabs.tsx
+++ b/kibbeh/src/ui/ProfileTabs.tsx
@@ -11,7 +11,7 @@ export const ProfileTabs: React.FC<ProfileTabsProps> = ({
 }) => {
   return (
     <div
-      className={`w-full flex items-center justify-around ${className}`}
+      className={`w-full flex items-center justify-between px-4 ${className}`}
       {...props}
     >
       <button

--- a/kibbeh/src/ui/UserProfile.tsx
+++ b/kibbeh/src/ui/UserProfile.tsx
@@ -24,7 +24,7 @@ export const UserProfile: React.FC<UserProfileProps> = ({
       />
       <ProfileTabs className="mt-4" activeTab="about" />
       <ProfileAbout
-        className={"mt-2"}
+        className={"mt-3"}
         username={user.username}
         followers={user.numFollowers}
         following={user.numFollowing}


### PR DESCRIPTION
Corrected some styles for the User Profile page.

Changed the `p` tag to a `div` tag because the global `p` tag styles font-weight is 500 and almost all elements that have 500 font-weight on Figma are 400 on the actual site.