### PR TITLE
Add Hover Text to Add To Calendar Drop Down

### DIFF
--- a/kibbeh/src/modules/scheduled-rooms/AddToCalendar.tsx
+++ b/kibbeh/src/modules/scheduled-rooms/AddToCalendar.tsx
@@ -134,7 +134,7 @@ const AddToCalendar: React.FC<AddToCalendarProps> = ({
   const urls = useMemo<CalendarURLs>(() => makeUrls(event), [event]);
 
   return (
-    <div className="relative">
+    <div className="relative" title="Add to Calendar">
       <DropdownController
         portal={false}
         overlay={(close) => (


### PR DESCRIPTION
Want to add hover text to the add to calendar drop down option for scheduled rooms so it is more
obvious what it does

re #2322