### PR TITLE
Initialize kibbeh .env in devcontainer

### DIFF
--- a/.devcontainer/scripts/environment.sh
+++ b/.devcontainer/scripts/environment.sh
@@ -20,3 +20,6 @@ EOL
 
 # shawarma
 echo "WEBRTC_LISTEN_IP=127.0.0.1" > shawarma/.env
+
+# kibbeh
+cp kibbeh/.env.example kibbeh/.env


### PR DESCRIPTION
I just removed kofta environment in [#2351](https://github.com/benawad/dogehouse/pull/2351). Now I realised I had to initialise kibbeh instead. Bcoz I stepped into kibbeh error