### PR TITLE
fix width of chat on wider layouts

### DIFF
--- a/kibbeh/src/ui/MainGrid.tsx
+++ b/kibbeh/src/ui/MainGrid.tsx
@@ -11,11 +11,11 @@ export const MainInnerGrid: React.FC<DashboardGridProps> = ({
 }) => {
   const screenType = useScreenType();
 
-  let gridTemplateColumns = "235px 640px 325px";
+  let gridTemplateColumns = "235px 640px 24.5vw";
   let myClassName = ``;
 
   if (screenType === "2-cols") {
-    gridTemplateColumns = "60px 640px 325px";
+    gridTemplateColumns = "60px 640px 24.5vw";
   } else if (screenType === "1-cols") {
     gridTemplateColumns = "60px 640px";
   } else if (screenType === "fullscreen") {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53215039/116202337-14754380-a700-11eb-9ac4-5d32a061042c.png)
The chat was set to 325px width I think, so I changed it to 24.5vw to accommodate people with larger screen sizes.