### PR TITLE
feat(pilaf): Add StackNavigationProps interface for navigation and route

### DIFF
--- a/pilaf/src/modules/profile/ProfileController.tsx
+++ b/pilaf/src/modules/profile/ProfileController.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { TitledHeader } from "../../components/header/TitledHeader";
 import { colors, fontFamily } from "../../constants/dogeStyle";
 import { useTokenStore } from "../auth/useTokenStore";
+import { StackNavigationProp } from "@react-navigation/stack";
 
 export const ProfileController: React.FC = () => {
   const setTokens = useTokenStore((s) => s.setTokens);

--- a/pilaf/src/modules/profile/ProfileController.tsx
+++ b/pilaf/src/modules/profile/ProfileController.tsx
@@ -4,7 +4,6 @@ import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { TitledHeader } from "../../components/header/TitledHeader";
 import { colors, fontFamily } from "../../constants/dogeStyle";
 import { useTokenStore } from "../auth/useTokenStore";
-import { StackNavigationProp } from "@react-navigation/stack";
 
 export const ProfileController: React.FC = () => {
   const setTokens = useTokenStore((s) => s.setTokens);

--- a/pilaf/src/navigation/RootNavigation.ts
+++ b/pilaf/src/navigation/RootNavigation.ts
@@ -1,5 +1,21 @@
-import { NavigationContainerRef, StackActions } from "@react-navigation/native";
+import {
+  NavigationContainerRef,
+  ParamListBase,
+  RouteProp,
+  StackActions,
+} from "@react-navigation/native";
 import * as React from "react";
+import { StackNavigationProp } from "@react-navigation/stack";
+
+// This allow to get route and navigation props
+
+export interface StackNavigationProps<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList = string
+> {
+  navigation: StackNavigationProp<ParamList, RouteName>;
+  route: RouteProp<ParamList, RouteName>;
+}
 
 // This allow to call navigation from outside a Navigator. Usefull for floating RoomController
 

--- a/pilaf/src/navigation/mainNavigator/RoomPage.tsx
+++ b/pilaf/src/navigation/mainNavigator/RoomPage.tsx
@@ -1,14 +1,10 @@
-import { RouteProp } from "@react-navigation/native";
 import React from "react";
 import { RoomController } from "../../modules/room/RoomController";
 import { RootStackParamList } from "../MainNavigator";
+import { StackNavigationProps } from "../RootNavigation";
 
-type RoomPageRouteProp = RouteProp<RootStackParamList, "Room">;
-
-type RoomPageProps = {
-  route: RoomPageRouteProp;
-};
-
-export const RoomPage: React.FC<RoomPageProps> = ({ route }) => {
+export const RoomPage: React.FC<
+  StackNavigationProps<RootStackParamList, "Room">
+> = ({ route }) => {
   return <RoomController roomId={route.params.roomId} />;
 };

--- a/pilaf/tokens.ts
+++ b/pilaf/tokens.ts
@@ -1,4 +1,2 @@
-export const accessToken =
-  undefined,
-export const refreshToken =
-  undefined,
+export const accessToken = undefined;
+export const refreshToken = undefined;


### PR DESCRIPTION
This PR adds a suggestion for dealing with navigation props and route props. In future versions this should also be adapted to the hook `useNavigation`. The desired behavior can be achieved as follows: 
```ts
const navigation = useNavigation<StackNavigationProps<RootStackParamList, "Room">>()
``` 