### PR TITLE
fix(kibbeh): removed inline styles from RoomChatList

### DIFF
--- a/kibbeh/src/modules/room/chat/RoomChatList.tsx
+++ b/kibbeh/src/modules/room/chat/RoomChatList.tsx
@@ -63,11 +63,6 @@ export const RoomChatList: React.FC<ChatListProps> = ({ room }) => {
     >
       <div
         className="w-full h-full mt-auto"
-        style={{
-          height: `${rowVirtualizer.totalSize}px`,
-          width: "100%",
-          position: "relative",
-        }}
       >
         {rowVirtualizer.virtualItems.map(
           ({ index: idx, start, measureRef, size }: VirtualItem) => {
@@ -75,17 +70,8 @@ export const RoomChatList: React.FC<ChatListProps> = ({ room }) => {
             return (
               <div
                 ref={measureRef}
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
-                  transform: `translateY(${
-                    messages[index].isWhisper ? start : start
-                  }px)`,
-                }}
                 key={messages[index].id}
-                className="py-1"
+                className="py-2 md:py-2"
               >
                 <div
                   className={`flex flex-col flex-shrink-0 w-full ${


### PR DESCRIPTION
Removed Inline styles that used position absolute and translate

#2356

![ex2](https://user-images.githubusercontent.com/49139988/116309790-6e105900-a766-11eb-9d6d-64f63815ecd2.png)
![ex3](https://user-images.githubusercontent.com/49139988/116309811-75376700-a766-11eb-9aa3-522487b14824.png)
![ex1](https://user-images.githubusercontent.com/49139988/116309859-87190a00-a766-11eb-991d-aa8d432d9ebf.png)
