### PR TITLE
chore: change `npm run` to `yarn` in translations

### DIFF
--- a/kibbeh/public/locales/af/translation.json
+++ b/kibbeh/public/locales/af/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Laai Meer",
     "loading": "Laai Tans...",

--- a/kibbeh/public/locales/am/translation.json
+++ b/kibbeh/public/locales/am/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "ተጨማሪ ይጫኑ",
     "loading": "በመጫን ላይ ...",

--- a/kibbeh/public/locales/ar/translation.json
+++ b/kibbeh/public/locales/ar/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "حمل المزيد",
     "loading": "جاري التحميل...",

--- a/kibbeh/public/locales/az/translation.json
+++ b/kibbeh/public/locales/az/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Daha çox yüklə",
     "loading": "Yüklənir...",

--- a/kibbeh/public/locales/bg/translation.json
+++ b/kibbeh/public/locales/bg/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "зареди още",
     "loading": "зареждане...",

--- a/kibbeh/public/locales/bn/translation.json
+++ b/kibbeh/public/locales/bn/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "আরো লোড করুন",
     "loading": "লোডিং...",

--- a/kibbeh/public/locales/cs/translation.json
+++ b/kibbeh/public/locales/cs/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Načíst více",
     "loading": "Načítám...",

--- a/kibbeh/public/locales/de-AT/translation.json
+++ b/kibbeh/public/locales/de-AT/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Zag mehr au",
     "loading": "Lona...",

--- a/kibbeh/public/locales/de/translation.json
+++ b/kibbeh/public/locales/de/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Mehr laden",
     "loading": "Lädt...",

--- a/kibbeh/public/locales/el/translation.json
+++ b/kibbeh/public/locales/el/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Περισσότερα",
     "loading": "Φόρτωση...",

--- a/kibbeh/public/locales/en-AU/translation.json
+++ b/kibbeh/public/locales/en-AU/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "ǝɹoɯ pɐoꞁ",
     "loading": "˙˙˙ƃuᴉpɐoꞁ",

--- a/kibbeh/public/locales/en-OWO/translation.json
+++ b/kibbeh/public/locales/en-OWO/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "0w0 Woad Mowe UwU",
     "loading": "<3 Woading... ;_;",

--- a/kibbeh/public/locales/en-PIRATE/translation.json
+++ b/kibbeh/public/locales/en-PIRATE/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "get some more",
     "loading": "loadin'",

--- a/kibbeh/public/locales/eo/translation.json
+++ b/kibbeh/public/locales/eo/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "ŝarĝi pli",
     "loading": "ŝarĝante...",

--- a/kibbeh/public/locales/et/translation.json
+++ b/kibbeh/public/locales/et/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "laadi rohkem",
     "loading": "laadib...",

--- a/kibbeh/public/locales/fa/translation.json
+++ b/kibbeh/public/locales/fa/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "نمایش بیشتر",
     "loading": "در حال بارگذاری",

--- a/kibbeh/public/locales/fi/translation.json
+++ b/kibbeh/public/locales/fi/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Lataa lisää",
     "loading": "Ladataan...",

--- a/kibbeh/public/locales/grc/translation.json
+++ b/kibbeh/public/locales/grc/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "φόρτωση περισσοτέρων",
     "loading": "φόρτωση...",

--- a/kibbeh/public/locales/gsw/translation.json
+++ b/kibbeh/public/locales/gsw/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Meh lade",
     "loading": "Am lade...",

--- a/kibbeh/public/locales/he/translation.json
+++ b/kibbeh/public/locales/he/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "טען עוד",
     "loading": "טוען...",

--- a/kibbeh/public/locales/hr/translation.json
+++ b/kibbeh/public/locales/hr/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "učitaj više",
     "loading": "učitavanje ...",

--- a/kibbeh/public/locales/is/translation.json
+++ b/kibbeh/public/locales/is/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "hlaða meira",
     "loading": "hleður...",

--- a/kibbeh/public/locales/ja/translation.json
+++ b/kibbeh/public/locales/ja/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "読み込む",
     "loading": "読込中...",

--- a/kibbeh/public/locales/kk/translation.json
+++ b/kibbeh/public/locales/kk/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "тағы да жүктеу",
     "loading": "жүктелуде...",

--- a/kibbeh/public/locales/li/translation.json
+++ b/kibbeh/public/locales/li/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Mieer laaje",
     "loading": "Laaje...",

--- a/kibbeh/public/locales/lt/translation.json
+++ b/kibbeh/public/locales/lt/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Pakrauti daugiau",
     "loading": "Kraunasi...",

--- a/kibbeh/public/locales/lv/translation.json
+++ b/kibbeh/public/locales/lv/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Ielādēt vairāk",
     "loading": "Ielāde...",

--- a/kibbeh/public/locales/ro/translation.json
+++ b/kibbeh/public/locales/ro/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Încarcă mai multe",
     "loading": "Se încarcă...",

--- a/kibbeh/public/locales/ru/translation.json
+++ b/kibbeh/public/locales/ru/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Загрузить еще",
     "loading": "Загрузка...",

--- a/kibbeh/public/locales/si/translation.json
+++ b/kibbeh/public/locales/si/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "තවත් පෙන්නන්න",
     "loading": "ලබා ගනිමින් පවතී...",

--- a/kibbeh/public/locales/sl/translation.json
+++ b/kibbeh/public/locales/sl/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Prikažite več",
     "loading": "Nalaganje...",

--- a/kibbeh/public/locales/so/translation.json
+++ b/kibbeh/public/locales/so/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "load more",
     "loading": "loading...",

--- a/kibbeh/public/locales/sq/translation.json
+++ b/kibbeh/public/locales/sq/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "ngarko më tepër",
     "loading": "duke ngarkuar...",

--- a/kibbeh/public/locales/sr-LATIN/translation.json
+++ b/kibbeh/public/locales/sr-LATIN/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "učitaj još",
     "loading": "učitavanje...",

--- a/kibbeh/public/locales/ta/translation.json
+++ b/kibbeh/public/locales/ta/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "மேலும் காட்டு",
     "loading": "பதிவேறுகிறது, காத்திருக்கவும்...",

--- a/kibbeh/public/locales/tp/translation.json
+++ b/kibbeh/public/locales/tp/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "tenpo kama la sin li lon",
     "loading": "sin li kama...",

--- a/kibbeh/public/locales/uk/translation.json
+++ b/kibbeh/public/locales/uk/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "завантажити ще",
     "loading": "завантажується",

--- a/kibbeh/public/locales/ur/translation.json
+++ b/kibbeh/public/locales/ur/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "مزید لوڈ کریں",
     "loading": "لوڈ ہو رہا ہے",

--- a/kibbeh/public/locales/uz/translation.json
+++ b/kibbeh/public/locales/uz/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "Ko'proq yuklash",
     "loading": "Yuklanmoqda...",

--- a/kibbeh/public/locales/vi/translation.json
+++ b/kibbeh/public/locales/vi/translation.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "if you change this file, do: npm run i18",
+  "_comment": "if you change this file, do: yarn i18",
   "common": {
     "loadMore": "tải thêm",
     "loading": "đang tải...",


### PR DESCRIPTION
I changed `npm run` to `yarn` in all the translation files.