### PR TITLE
fix(kibbeh): fix intersection observer hook

### DIFF
--- a/kibbeh/src/modules/user/FollowingController.tsx
+++ b/kibbeh/src/modules/user/FollowingController.tsx
@@ -33,7 +33,7 @@ const Page = ({
 }) => {
   const conn = useConn();
   const ref = useRef<HTMLDivElement | null>(null);
-  const entry = useIntersectionObserver(ref, {});
+  const { setNode, entry } = useIntersectionObserver(ref);
   const {
     mutateAsync,
     isLoading: followLoading,
@@ -53,13 +53,19 @@ const Page = ({
     vars
   );
 
-  useEffect(() => {
-    const shouldLoadMore = !!entry?.isIntersecting;
+  const [shouldLoadMore, setShouldLoadMore] = useState(false);
 
+  useEffect(() => {
+    setShouldLoadMore(!!entry?.isIntersecting);
+  }, [entry?.isIntersecting]);
+
+  useEffect(() => {
     if (shouldLoadMore && data?.nextCursor) {
+      console.log("HERE");
       onLoadMore(data.nextCursor!);
+      setShouldLoadMore(false);
     }
-  }, [data?.nextCursor, entry?.isIntersecting, onLoadMore]);
+  }, [data?.nextCursor, entry?.isIntersecting, onLoadMore, shouldLoadMore]);
 
   if (isLoading) {
     return <CenterLoader />;
@@ -126,7 +132,7 @@ const Page = ({
         </div>
       ))}
       {isLastPage && data.nextCursor && (
-        <div ref={ref} className={`flex justify-center py-5`}>
+        <div ref={setNode} className={`flex justify-center py-5`}>
           <Spinner />
         </div>
       )}

--- a/kibbeh/src/modules/user/FollowingController.tsx
+++ b/kibbeh/src/modules/user/FollowingController.tsx
@@ -61,7 +61,6 @@ const Page = ({
 
   useEffect(() => {
     if (shouldLoadMore && data?.nextCursor) {
-      console.log("HERE");
       onLoadMore(data.nextCursor!);
       setShouldLoadMore(false);
     }

--- a/kibbeh/src/shared-hooks/useIntersectionObserver.ts
+++ b/kibbeh/src/shared-hooks/useIntersectionObserver.ts
@@ -10,11 +10,11 @@ export const useIntersectionObserver = ({
   const observer = useRef<IntersectionObserver>(null);
 
   useEffect(() => {
-    if (node) {
-      if (observer.current) {
-        observer?.current?.disconnect();
-      }
+    if (observer.current) {
+      observer?.current?.disconnect();
+    }
 
+    if (node) {
       if (window.IntersectionObserver) {
         observer.current = new window.IntersectionObserver(
           ([newEntry]) => setEntry(newEntry),
@@ -25,17 +25,15 @@ export const useIntersectionObserver = ({
           }
         );
 
-        const { current: currentObserver } = observer;
-
-        currentObserver.observe(node);
-
-        return () => {
-          if (currentObserver) {
-            currentObserver.disconnect();
-          }
-        };
+        observer.current.observe(node);
       }
     }
+
+    return () => {
+      if (observer?.current) {
+        observer?.current?.disconnect();
+      }
+    };
   }, [threshold, root, rootMargin, node]);
 
   return { setNode, entry };

--- a/kibbeh/src/shared-hooks/useIntersectionObserver.ts
+++ b/kibbeh/src/shared-hooks/useIntersectionObserver.ts
@@ -4,9 +4,9 @@ export const useIntersectionObserver = ({
   threshold = 0,
   root = null,
   rootMargin = "0%",
-}): IntersectionObserverEntry | undefined => {
+}) => {
   const [entry, setEntry] = useState<IntersectionObserverEntry>();
-  const [node, setNode] = useState<Element>();
+  const [node, setNode] = useState<HTMLElement | null>(null);
   const observer = useRef<IntersectionObserver>(null);
 
   useEffect(() => {


### PR DESCRIPTION
The intersection observer hook I created in #2491 was only getting set on mount. This fixes that and the entry should be updating correctly now.

Relates to #2485 