### PR TITLE
Baklava: Set min width and min height to window

### DIFF
--- a/baklava/src/electron.ts
+++ b/baklava/src/electron.ts
@@ -68,6 +68,8 @@ function createMainWindow() {
   mainWindow = new BrowserWindow({
     width: 1500,
     height: 800,
+    minWidth: 800,
+    minHeight: 640,
     autoHideMenuBar: true,
     webPreferences: {
       nodeIntegration: true,


### PR DESCRIPTION
add `minWidth` and `minHeight` properties to the `createMainWindow()` function.

![Screenshot 2021-05-03 at 10 04 48](https://user-images.githubusercontent.com/76838845/116858947-1efb7580-abf7-11eb-8b00-6f383fb99a6f.png)
This is what the min-width and height looks like, it is also one pixel above the breakpoint to switch to mobile view.