### PR TITLE
fix(global): update run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 docker-compose -f docker-compose.yml -f docker-compose.$1.yml ${@:2}


### PR DESCRIPTION
the script now search the user's whole path instead of just `/bin/`, so the script will now work if bash is not installed
on `/bin/`.