### PR TITLE
fix(baklava): temp disable discord auth on electron (#2577)

### DIFF
--- a/baklava/src/constants.ts
+++ b/baklava/src/constants.ts
@@ -25,7 +25,6 @@ export const ALLOWED_HOSTS = [
   "api.dogehouse.tv",
   "dogehouse.tv",
   "github.com",
-  "discord.com",
   "localhost",
   "staging.dogehouse.tv",
   "doge-staging.stripcode.dev",

--- a/baklava/src/constants.ts
+++ b/baklava/src/constants.ts
@@ -25,6 +25,7 @@ export const ALLOWED_HOSTS = [
   "api.dogehouse.tv",
   "dogehouse.tv",
   "github.com",
+  "discord.com",
   "localhost",
   "staging.dogehouse.tv",
   "doge-staging.stripcode.dev",

--- a/baklava/src/electron.ts
+++ b/baklava/src/electron.ts
@@ -69,7 +69,7 @@ function createMainWindow() {
     width: 1500,
     height: 800,
     minWidth: 400,
-    minHeight: 640,
+    minHeight: 600,
     autoHideMenuBar: true,
     webPreferences: {
       nodeIntegration: true,

--- a/kibbeh/src/modules/landing-page/LoginPage.tsx
+++ b/kibbeh/src/modules/landing-page/LoginPage.tsx
@@ -1,3 +1,4 @@
+import isElectron from "is-electron";
 import { useRouter } from "next/router";
 import React, { useCallback, useContext, useEffect } from "react";
 import { LgLogo } from "../../icons";
@@ -139,12 +140,16 @@ export const LoginPage: React.FC = () => {
               <SvgSolidTwitter width={20} height={20} />
               Log in with Twitter
             </LoginButton>
-            <LoginButton
-              oauthUrl={`${apiBaseUrl}/auth/discord/web${queryParams}`}
-            >
-              <SvgSolidDiscord width={20} height={20} />
-              Log in with Discord
-            </LoginButton>
+            {!isElectron() ? (
+              <LoginButton
+                oauthUrl={`${apiBaseUrl}/auth/discord/web${queryParams}`}
+              >
+                <SvgSolidDiscord width={20} height={20} />
+                Log in with Discord
+              </LoginButton>
+            ) : (
+              <></>
+            )}
             {!__prod__ ? (
               <LoginButton
                 dev


### PR DESCRIPTION
- temporarily disable discord auth on electron *(#2577)*

why did i do this?
`nodeIntegration: true` makes discord.com think we are on discord desktop app and it tries to load its modules *(which we don't have)* that ends up breaking the discord oauth workflow. so for now this fix should work but we probably want discord oauth in the future *(ill have to do some research for that)*