### PR TITLE
fix: remodding a mod won't unmod them in UI

### DIFF
--- a/kibbeh/src/shared-hooks/useMainWsHandler.tsx
+++ b/kibbeh/src/shared-hooks/useMainWsHandler.tsx
@@ -255,7 +255,7 @@ export const useMainWsHandler = () => {
           );
         }
       ),
-      conn.addListener<any>("mod_changed", ({ userId, roomId }) => {
+      conn.addListener<any>("mod_changed", ({ userId, roomId, isMod }) => {
         updateQuery(["joinRoomAndGetInfo", roomId], (data) =>
           !data || "error" in data
             ? data
@@ -267,7 +267,7 @@ export const useMainWsHandler = () => {
                         ...x,
                         roomPermissions: mergeRoomPermission(
                           x.roomPermissions,
-                          { isMod: !x.roomPermissions?.isMod }
+                          { isMod }
                         ),
                       }
                     : x

--- a/kousa/lib/kousa/room.ex
+++ b/kousa/lib/kousa/room.ex
@@ -177,7 +177,7 @@ defmodule Kousa.Room do
           room_id,
           %{
             op: "mod_changed",
-            d: %{roomId: room_id, userId: user_id}
+            d: %{roomId: room_id, userId: user_id, isMod: true}
           }
         )
 
@@ -199,7 +199,7 @@ defmodule Kousa.Room do
           room_id,
           %{
             op: "mod_changed",
-            d: %{roomId: room_id, userId: user_id}
+            d: %{roomId: room_id, userId: user_id, isMod: false}
           }
         )
 
@@ -218,7 +218,7 @@ defmodule Kousa.Room do
           room_id,
           %{
             op: "mod_changed",
-            d: %{roomId: room_id, userId: user_id}
+            d: %{roomId: room_id, userId: user_id, isMod: false}
           }
         )
 

--- a/kousa/test/broth/room/set_auth_test.exs
+++ b/kousa/test/broth/room/set_auth_test.exs
@@ -25,7 +25,7 @@ defmodule BrothTest.Room.SetAuthTest do
   end
 
   describe "the using room:set_auth with mod" do
-    test "makes the person a mod", t do
+    test "makes the person a mod and unmods them", t do
       room_id = t.room_id
 
       # make sure the user is in there.
@@ -53,18 +53,44 @@ defmodule BrothTest.Room.SetAuthTest do
       # both clients get notified
       WsClient.assert_frame_legacy(
         "mod_changed",
-        %{"userId" => ^speaker_id, "roomId" => ^room_id},
+        %{"userId" => ^speaker_id, "roomId" => ^room_id, "isMod" => true},
         t.client_ws
       )
 
       WsClient.assert_frame_legacy(
         "mod_changed",
-        %{"userId" => ^speaker_id, "roomId" => ^room_id},
+        %{"userId" => ^speaker_id, "roomId" => ^room_id, "isMod" => true},
         speaker_ws
       )
 
-      assert Beef.RoomPermissions.get(speaker_id, room_id).isMod
+      assert Beef.RoomPermissions.mod?(speaker_id, room_id)
+
+      # unmods the person
+      WsClient.send_msg(
+        t.client_ws,
+        "room:set_auth",
+        %{
+          "userId" => speaker_id,
+          "level" => "user"
+        }
+      )
+
+      # both clients get notified
+      WsClient.assert_frame_legacy(
+        "mod_changed",
+        %{"userId" => ^speaker_id, "roomId" => ^room_id, "isMod" => false},
+        t.client_ws
+      )
+
+      WsClient.assert_frame_legacy(
+        "mod_changed",
+        %{"userId" => ^speaker_id, "roomId" => ^room_id, "isMod" => false},
+        speaker_ws
+      )
+
+      refute Beef.RoomPermissions.mod?(speaker_id, room_id)
     end
+
   end
 
   describe "the set_auth command can" do


### PR DESCRIPTION
when `mod_changed` is dispatched, the UI does `isMod = !isMod`. This is a problem if somebody sends a `room:set_auth = mod`  on an already modded user.

- added tests

fixes #2583