### PR TITLE
feat(dolma): adding the dolma chat token transpiler as instructed

### DIFF
--- a/.github/workflows/dolma-npm_deploy.yaml
+++ b/.github/workflows/dolma-npm_deploy.yaml
@@ -1,0 +1,37 @@
+name: dolma:npm_publish
+on:
+  push:
+    paths:
+      - "dolma/**"
+    branches:
+      - staging
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install deps
+        working-directory: dolma
+        run: yarn
+      - name: Build
+        working-directory: dolma
+        run: yarn build
+      - name: Publish if version has been updated
+        uses: pascalgn/npm-publish-action@1.3.7
+        with: # All of theses inputs are optional
+          tag_name: "v%s"
+          tag_message: "v%s"
+          create_tag: "true"
+          commit_pattern: "^Release (\\S+)"
+          workspace: "dolma"
+          publish_command: "yarn"
+          publish_args: "--non-interactive"
+        env: # More info about the environment variables in the README
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "packages": [
       "kebab",
       "kibbeh",
-      "dinner"
+      "dinner",
+      "dolma"
     ],
     "nohoist": [
       "**"


### PR DESCRIPTION
I have created a token transpiler which will transpile tokens for DogeHouse chat.  I have been given
the go ahead to pr it to the monorepo so that it can be pushed to the dogehouse namespace on npm,
and so that it can be integrated into the platform.