### PR TITLE
feat(dolma): adding the dolma chat token transpiler as instructed

### DIFF
--- a/.github/workflows/dolma-npm_deploy.yaml
+++ b/.github/workflows/dolma-npm_deploy.yaml
@@ -1,0 +1,37 @@
+name: dolma:npm_publish
+on:
+  push:
+    paths:
+      - "dolma/**"
+    branches:
+      - staging
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install deps
+        working-directory: dolma
+        run: yarn
+      - name: Build
+        working-directory: dolma
+        run: yarn build
+      - name: Publish if version has been updated
+        uses: pascalgn/npm-publish-action@1.3.7
+        with: # All of theses inputs are optional
+          tag_name: "v%s"
+          tag_message: "v%s"
+          create_tag: "true"
+          commit_pattern: "^Release (\\S+)"
+          workspace: "dolma"
+          publish_command: "yarn"
+          publish_args: "--non-interactive"
+        env: # More info about the environment variables in the README
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 /kebab/ @overlisted
 /baklava/ @amitojsingh366
+/dolma/ @HoloPanio

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
 | [pilaf](pilaf)       |   React Native App    |
 | [kibbeh](kibbeh)     |   Next.js frontend    |
 | [kebab](kebab)       |      API Client       |
+| [dolma](dolma)       | Chat Token Transcoder |
+
 
 ## Branches
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,6 +13,7 @@ module.exports = {
         "pilaf",
         "shawarma",
         "kebab",
+        "dolma"
       ],
     ],
   },

--- a/dolma/LICENSE
+++ b/dolma/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 HoloPanio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dolma/README.md
+++ b/dolma/README.md
@@ -1,0 +1,121 @@
+<h1 align=center>
+Dolma Token Transcoder<br>
+<a href="https://www.npmjs.com/package/@dogehouse/dolma"><img src="https://img.shields.io/npm/v/@dogehouse/dolma?style=for-the-badge"></a>
+</h1>
+This is a token transcoder that is used to encode and decode DogeHouse chat message token arrays.  This package is written for bot/bot library devlopers to be able to easily transcode dogehouse chat message tokens.  
+
+## How to install
+To install this, simply go to your project and run the following command:
+```cmd
+npm install dolma@latest --save
+```
+
+## How to use
+This will show you how to encode and decode tokens
+
+### Encoding Tokens
+In this example, you will see multiple ways to encode your tokens.  The first one is in plain text.  You can pass any string into the encoder and it will convert it into an array of Message Tokens.
+
+```ts
+import { dolma } from 'dolma';
+
+const str = "I'm @HoloPanio, and I'd like to goto `Paris, France` one day :catJAM: Also, https://google.com is epic!";
+
+const tokens = dolma.encode(str);
+
+console.log(tokens);
+
+/**
+Returns: 
+[
+  { t: 'text', v: "I'm" },
+  { t: 'mention', v: 'HoloPanio' },
+  { t: 'text', v: ',' },
+  { t: 'text', v: 'and' },
+  { t: 'text', v: "I'd" },
+  { t: 'text', v: 'like' },
+  { t: 'text', v: 'to' },
+  { t: 'text', v: 'goto' },
+  { t: 'block', v: 'Paris, France' },
+  { t: 'text', v: 'one' },
+  { t: 'text', v: 'day' },
+  { t: 'emote', v: 'catJAM' },
+  { t: 'text', v: 'Also,' },
+  { t: 'link', v: 'https://google.com' },
+  { t: 'text', v: 'is' },
+  { t: 'text', v: 'epic!' }
+]
+*/
+```
+
+In this example, you will see that you can have an mixed array with strings, and unitokens!  A unitoken is a token object where you define your object key as the token type, and the value as the value of the token, doing so would look like such: `{link: "https://google.com"}`, and this can be done for all token types.
+
+```ts
+import { dolma } from 'dolma';
+
+const arr = ["I'm", {mention: "HoloPanio"},", and I'd like to goto", {block: "Paris, France"},"one day", {emote: "catJAM"}, "Also",{link: 'https://google.com'}, "is epic!"];
+
+const tokens = dolma.encode(str);
+
+console.log(tokens);
+
+/**
+Returns: 
+[
+  { t: 'text', v: "I'm" },
+  { t: 'mention', v: 'HoloPanio' },
+  { t: 'text', v: ',' },
+  { t: 'text', v: 'and' },
+  { t: 'text', v: "I'd" },
+  { t: 'text', v: 'like' },
+  { t: 'text', v: 'to' },
+  { t: 'text', v: 'goto' },
+  { t: 'block', v: 'Paris, France' },
+  { t: 'text', v: 'one' },
+  { t: 'text', v: 'day' },
+  { t: 'emote', v: 'catJAM' },
+  { t: 'text', v: 'Also,' },
+  { t: 'link', v: 'https://google.com' },
+  { t: 'text', v: 'is' },
+  { t: 'text', v: 'epic!' }
+]
+*/
+```
+You can also pass in message tokens like `{t: 'link', v: 'https://google.com'}`, and it will work because the encoder checks for all possible methods that can be used.
+
+
+### Decoding Tokens
+When you get a payload from DogeHouse, you can use the decode method which will take the tokens, and turn it into a raw text string when you can use anywhere you please.  The decode method will always encode the data sent to it to ensure that the data is parsed correctly, so that means you can also pass in un-encoded data, such as the array in the previous example, and will print out a plain text string.  In this example, we will take the array from above, and return it to a plain text string using the decode method.
+
+```ts
+import { dolma } from 'dolma';
+
+const tokens = [
+  { t: 'text', v: "I'm" },
+  { t: 'mention', v: 'HoloPanio' },
+  { t: 'text', v: ',' },
+  { t: 'text', v: 'and' },
+  { t: 'text', v: "I'd" },
+  { t: 'text', v: 'like' },
+  { t: 'text', v: 'to' },
+  { t: 'text', v: 'goto' },
+  { t: 'block', v: 'Paris, France' },
+  { t: 'text', v: 'one' },
+  { t: 'text', v: 'day' },
+  { t: 'emote', v: 'catJAM' },
+  { t: 'text', v: 'Also,' },
+  { t: 'link', v: 'https://google.com' },
+  { t: 'text', v: 'is' },
+  { t: 'text', v: 'epic!' }
+];
+
+const message = dolma.decode(tokens);
+
+console.log(message);
+
+/**
+Returns: 
+
+I'm @HoloPanio , and I'd like to goto `Paris, France` one day :catJAM: Also, https://google.com is epic!
+*/
+```

--- a/dolma/package.json
+++ b/dolma/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@dogehouse/dolma",
+  "author": "Jackson Roberts <jackson@holopanio.com>",
+  "description": "A chat token transcoder for DogeHouse and associated projects",
+  "version": "1.1.3",
+  "license": "MIT",
+  "main": "src/index",
+  "scripts": {
+    "clean": "tsc -b . --clean",
+    "build": "tsc;"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HoloPanio/dolma.git"
+  },
+  "keywords": [
+    "@dogehouse/dolma",
+    "dogehouse",
+    "doghouse-tokens"
+  ],
+  "bugs": {
+    "url": "https://github.com/HoloPanio/dolma/issues"
+  },
+  "homepage": "https://github.com/HoloPanio/dolma#readme",
+  "dependencies": {
+    "@types/node": "^15.0.2"
+  }
+}

--- a/dolma/src/index.ts
+++ b/dolma/src/index.ts
@@ -1,0 +1,20 @@
+import { decodeTokens } from "./lib/decode";
+import { encodeTokens } from "./lib/encode";
+import { MessageToken, Unitoken } from "./util/types/token";
+
+interface RootMethodResponse {
+	encoded: MessageToken[],
+	decoded: string
+}
+
+export * from './util/types/token';
+
+export function dolma(values?: Array<Unitoken | MessageToken | string> | string): RootMethodResponse {
+	return {
+		encoded: encodeTokens(values ?? ""),
+		decoded: decodeTokens(values ?? "")
+	}
+}
+
+dolma['encode'] = encodeTokens;
+dolma['decode'] = decodeTokens

--- a/dolma/src/lib/decode.ts
+++ b/dolma/src/lib/decode.ts
@@ -1,0 +1,28 @@
+import { MessageToken, Unitoken } from "../util/types/token";
+import { encodeTokens } from "./encode";
+
+export function decodeTokens(all: Array<Unitoken | MessageToken | string> | string): string {
+	const tokens = encodeTokens(all);
+	let vals: string[] = [];
+
+	tokens.map(tkn => {
+		if (tkn.t == 'text') return vals.push(tkn.v);
+		if (tkn.t == 'block') return vals.push(`\`${tkn.v}\``);
+		if (tkn.t == 'emote') return vals.push(`:${tkn.v}:`);
+		if (tkn.t == 'mention') return vals.push(`@${tkn.v}`);
+		if (tkn.t == 'link') return vals.push(tkn.v);
+	});
+
+	let ret: string[] = [];
+	const len = vals.length
+	vals.forEach((val, index) => {
+		const strayValues = [",", "."]
+		if (strayValues.includes(val)) {
+			ret[ret.length-1] += val;
+		} else {
+			ret.push(val);
+		}
+	});
+
+	return ret.join(' ');
+}

--- a/dolma/src/lib/encode.ts
+++ b/dolma/src/lib/encode.ts
@@ -1,0 +1,29 @@
+import { MessageToken, Unitoken } from "../util/types/token";
+import { decodeTokens } from "./decode";
+import { filterString } from "./filterString";
+import { filterUnitoken } from "./filterUnitoken";
+
+export function encodeTokens(message: Array<Unitoken | MessageToken | string> | string): MessageToken[] {
+	const tokens: MessageToken[] = [];
+	if (!message) return tokens;
+
+	if (typeof message == 'string') {
+		filterString(message).map(tk => tokens.push(tk));
+		return tokens;
+	}
+
+	if (typeof message == 'object') {
+		message.forEach((item: any, index) => {
+			const unitoken = filterUnitoken(item);
+			const isToken = Object.keys(item).includes('t') && Object.keys(item).includes('v');
+
+			if (typeof item == 'string') return filterString(item).map(tk => tokens.push(tk));
+			if (unitoken !== null) return tokens.push(unitoken);
+			if (isToken) return tokens.push(item);
+
+			return;
+		})
+	}
+
+	return tokens;
+}

--- a/dolma/src/lib/filterString.ts
+++ b/dolma/src/lib/filterString.ts
@@ -1,0 +1,24 @@
+import { validationRegex } from "../util/regex";
+import { MessageToken } from "../util/types/token";
+import { newToken, validator } from "./token";
+
+export function filterString(message: string) {
+	const tokens: MessageToken[] = []
+	const vals = message.trim().split(validationRegex.global).filter(e => e != "" && e != " " && e != undefined).map(e => e.trim());
+
+	vals.forEach(e => {
+		const block = validator.getBlock(e);
+		const mention = validator.getMention(e);
+		const emote = validator.getEmote(e);
+		const link = validator.getLink(e);
+
+		if (block) return tokens.push(newToken('block', block));
+		if (mention) return tokens.push(newToken('mention', mention)); 
+		if (emote) return tokens.push(newToken('emote', emote)); 
+		if (link) return tokens.push(newToken('link', link)); 
+
+		e.split(" ").map(str => tokens.push(newToken('text', str)));
+	});
+
+	return tokens;
+}

--- a/dolma/src/lib/filterUnitoken.ts
+++ b/dolma/src/lib/filterUnitoken.ts
@@ -1,0 +1,25 @@
+import { MessageToken, MessageTokenType, Unitoken } from "../util/types/token";
+import { newToken } from "./token";
+
+export function filterUnitoken(token: any): MessageToken | null {
+	const keys = Object.keys(token);
+	const allowedKeys = ['mention', 'emote', 'block', 'link'];
+
+	if (keys.length > 1 || !allowedKeys.includes(keys[0])) return null;
+
+	const key = keys[0];
+
+	const mention = token['mention'] ?? "invalidMention";
+	const emote = token['emote'] ?? "invalidEmote";
+	const block = token['block'] ?? "invalidBlock";
+	const link = token['link'] ?? "https://invalid.link";
+	const text = token['text'] ?? "invalidText";
+
+	if (key == 'mention') return newToken('mention', mention);
+	if (key == 'emote') return newToken("emote", emote);
+	if (key == 'block') return newToken("block", block);
+	if (key == 'link') return newToken("link", link);
+	if (key == 'text') return newToken("text", text);
+
+	return null;
+}

--- a/dolma/src/lib/token.ts
+++ b/dolma/src/lib/token.ts
@@ -1,0 +1,36 @@
+import { validationRegex } from "../util/regex";
+import { MessageToken, MessageTokenType } from "../util/types/token";
+
+export function newToken(token: MessageTokenType, value: string): MessageToken {
+	const genToken = (t: MessageTokenType, v: string) => { return {t, v} }
+
+	let tkn = token;
+	let val = value;
+
+	if (tkn == 'block') val = value.trim();
+
+	return genToken(tkn, val);
+	
+}
+
+export const validator = {
+	getBlock(str: string): string | false {
+		if (str.match(validationRegex.block)) return str.replace(validationRegex.block, '$1');
+		else return false;
+	},
+
+	getEmote(str: string): string | false {
+		if (str.match(validationRegex.emote)) return str.replace(validationRegex.emote, '$1');
+		else return false;
+	},
+
+	getMention(str: string): string | false {
+		if (str.match(validationRegex.mention)) return str.replace(validationRegex.mention, '$1');
+		else return false;
+	},
+
+	getLink(str: string): string | false {
+		if (str.match(validationRegex.link)) return str.replace(validationRegex.link, '$1');
+		else return false;
+	}
+}

--- a/dolma/src/util/regex.ts
+++ b/dolma/src/util/regex.ts
@@ -1,0 +1,8 @@
+export const validationRegex = {
+	link: /(https?\:\/\/[^ ]+)/gi,
+	mention: /\@([a-zA-Z0-9_]{4,})/gi,
+	emote: /\:([a-z0-9]+)\:/gi,
+	block: /\`(.*?)\`/gi,
+
+	global: /(\`.*?\`)|(\@[a-zA-Z0-9_]{4,})|(\:[a-z0-9]+\:)|(https?\:\/\/[^ ]+)/gi
+}

--- a/dolma/src/util/types/token.ts
+++ b/dolma/src/util/types/token.ts
@@ -1,0 +1,27 @@
+export const tokenTypes = [ 
+	'text',
+	'mention',
+	'link',
+	'emote',
+	'block'
+] as const;
+
+export type MessageTokenType = 
+	| 'text'
+	| 'mention'
+	| 'link'
+	| 'emote'
+	| 'block'
+
+export interface MessageToken {
+	t: MessageTokenType | string;
+	v: string;
+}
+
+export interface Unitoken {
+	mention?: string,
+	link?: string,
+	emote?: string,
+	block?: string
+	text?: string
+}

--- a/dolma/tsconfig.json
+++ b/dolma/tsconfig.json
@@ -1,0 +1,71 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                         /* Enable incremental compilation */
+    "target": "es5",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                                   /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                             /* Allow javascript files to be compiled. */
+    // "checkJs": true,                             /* Report errors in .js files. */
+    // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    // "outFile": "./",                             /* Concatenate and emit output to single file. */
+    // "outDir": "./",                              /* Redirect output structure to the directory. */
+    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                           /* Enable project compilation */
+    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+    // "removeComments": true,                      /* Do not emit comments to output. */
+    // "noEmit": true,                              /* Do not emit outputs. */
+    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                                 /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                    /* Enable strict null checks. */
+    // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                      /* Report errors on unused locals. */
+    // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+    // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+    // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                             /* List of folders to include type definitions from. */
+    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                           /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "packages": [
       "kebab",
       "kibbeh",
-      "dinner"
+      "dinner",
+      "dolma"
     ],
     "nohoist": [
       "**"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,6 +1853,14 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dogehouse/dolma@workspace:dolma":
+  version: 0.0.0-use.local
+  resolution: "@dogehouse/dolma@workspace:dolma"
+  dependencies:
+    "@types/node": ^15.0.2
+  languageName: unknown
+  linkType: soft
+
 "@dogehouse/kebab@workspace:kebab":
   version: 0.0.0-use.local
   resolution: "@dogehouse/kebab@workspace:kebab"
@@ -4357,6 +4365,13 @@ __metadata:
   version: 14.14.44
   resolution: "@types/node@npm:14.14.44"
   checksum: 5c4db716325fc8a25b5b76b800acf0ff00c8fa1e7cfcb764fc79d79594939488cb9d2a756e188eb8e8a36da51e8e2be1ffe859be901b338779cb0aa12ad73b3a
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^15.0.2":
+  version: 15.0.2
+  resolution: "@types/node@npm:15.0.2"
+  checksum: ea8dd741bf16ad3318cca505783b7c211a5c8bea49202f99ba88d2ce8a804e994e1fd1b575b994e434e8b8ead810da966d588ea112998f8fe8d95cd74c396f8a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I have created a token transpiler which will transpile tokens for DogeHouse chat. I have been given
the go ahead to pr it to the monorepo so that it can be pushed to the dogehouse namespace on npm,
and so that it can be integrated into the platform.