### PR TITLE
fix(kibbeh): made Twemojis have an alt text (and mathematically centred the emojis)

### DIFF
--- a/kibbeh/src/styles/globals.css
+++ b/kibbeh/src/styles/globals.css
@@ -132,11 +132,13 @@ textarea {
 }
 
 img.emoji {
-  height: 1.3em;
-  width: 1.3em;
+  height: 1.2rem;
+  width: 1.2rem;
   margin: 0 0.05em 0 0.1em;
-  vertical-align: text-top;
-  display: inline;
+  top: -0.1em;
+  vertical-align: middle;
+  display: inline-block;
+  position: relative;
   -webkit-user-drag: none;
   -moz-user-drag: none;
   -o-user-drag: none;

--- a/kibbeh/src/ui/Twemoji.tsx
+++ b/kibbeh/src/ui/Twemoji.tsx
@@ -27,6 +27,7 @@ export const ParseTextToTwemoji: React.FC<TwemojiProps> = ({
             key={i}
             className={`emoji ${className || ""}`}
             src={parse(e)[0].url}
+            alt={parse(e)[0].text}
           />
         ) : (
           <React.Fragment key={i}>{e}</React.Fragment>


### PR DESCRIPTION
nothing serious

screenshot: 
![image](https://user-images.githubusercontent.com/55450464/118012759-1246f200-b35a-11eb-96a5-a3e76892ee82.png)
