### PR TITLE
refactor: make user:admin_update require id instead of username

### DIFF
--- a/kebab/src/websocket/wrapper.ts
+++ b/kebab/src/websocket/wrapper.ts
@@ -169,14 +169,14 @@ export const wrap = (connection: Connection) => ({
     userCreateBot: (username: string): Promise<CreateBotResponse> =>
       connection.sendCall(`user:create_bot`, { username }),
     userAdminUpdate: (
-      username: string,
+      id: UUID,
       user: {
         staff?: boolean;
         contributions?: number;
       }
     ) =>
       connection.sendCall(`user:admin_update`, {
-        username,
+        id,
         user,
       }),
     ban: (username: string, reason: string) =>

--- a/kibbeh/src/modules/admin/AdminPageForm.tsx
+++ b/kibbeh/src/modules/admin/AdminPageForm.tsx
@@ -62,50 +62,6 @@ export const AdminPageForm: React.FC<SearchUsersProps> = ({}) => {
           {t("pages.admin.ban")}
         </Button>
       </div>
-      <div className="mt-6">
-        <h3 className="text-primary-100">{t("pages.admin.usrStaff")}</h3>
-
-        <label className="inline-flex mb-4">
-          <div className={`text-primary-100`}>{t("pages.admin.staff")}</div>
-          <input
-            type="checkbox"
-            className="ml-2 mt-1"
-            checked={isStaff}
-            onChange={(e) => setIsStaff(e.target.checked)}
-          />
-        </label>
-        <div className="flex">
-          <Button
-            onClick={() => {
-              wrapper.mutation.userAdminUpdate(username, { staff: isStaff });
-            }}
-          >
-            {t("common.save")}
-          </Button>
-        </div>
-      </div>
-      <div className="mt-6">
-        <h3 className="text-primary-100">
-          {t("pages.admin.usrContributions")}
-        </h3>
-        <Input
-          className={`mb-4`}
-          autoFocus
-          placeholder={t("pages.admin.contributions")}
-          value={contributions}
-          onChange={(e) => setContributions(Number(e.target.value))}
-          type="number"
-        />
-        <div className="flex pb-5">
-          <Button
-            onClick={() => {
-              wrapper.mutation.userAdminUpdate(username, { contributions });
-            }}
-          >
-            {t("common.save")}
-          </Button>
-        </div>
-      </div>
     </MiddlePanel>
   );
 };

--- a/kibbeh/src/ui/ProfileAdmin.tsx
+++ b/kibbeh/src/ui/ProfileAdmin.tsx
@@ -43,7 +43,7 @@ export const ProfileAdmin: React.FC<ProfileAdminProps> = ({
             size="tiny"
             className="ml-4"
             onClick={() => {
-              wrapper.mutation.userAdminUpdate(user.username, {
+              wrapper.mutation.userAdminUpdate(user.id, {
                 contributions,
               });
             }}
@@ -65,7 +65,7 @@ export const ProfileAdmin: React.FC<ProfileAdminProps> = ({
             size="tiny"
             className="ml-4"
             onClick={() => {
-              wrapper.mutation.userAdminUpdate(user.username, {
+              wrapper.mutation.userAdminUpdate(user.id, {
                 staff: isStaff,
               });
             }}

--- a/kousa/lib/broth/message/user/admin_update.ex
+++ b/kousa/lib/broth/message/user/admin_update.ex
@@ -6,7 +6,7 @@ defmodule Broth.Message.User.AdminUpdate do
 
   @primary_key false
   embedded_schema do
-    field(:username, :string)
+    field(:id, :binary_id)
     embeds_one(:user, User)
   end
 
@@ -20,14 +20,14 @@ defmodule Broth.Message.User.AdminUpdate do
   @impl true
   def changeset(initializer \\ %__MODULE__{}, data) do
     initializer
-    |> cast(data, [:username])
-    |> validate_required([:username])
+    |> cast(data, [:id])
+    |> validate_required([:id])
     |> cast_embed(:user,
       with:
         {__MODULE__, :user_admin_changeset,
          [
-           if(not is_nil(data["username"]),
-             do: Users.get_by_username(data["username"]),
+           if(not is_nil(data["id"]),
+             do: Users.get_by_id(data["id"]),
              else: %User{}
            )
          ]},

--- a/kousa/test/broth/user/admin_update_test.exs
+++ b/kousa/test/broth/user/admin_update_test.exs
@@ -27,7 +27,7 @@ defmodule BrothTest.User.AdminUpdateTest do
     test "doesn't work for not-ben awad", t do
       ref =
         WsClient.send_call(t.staff_client_ws, "user:admin_update", %{
-          "username" => t.staff_user.username,
+          "id" => t.staff_user.id,
           "user" => %{
             "staff" => true,
             "contributions" => 100
@@ -40,7 +40,7 @@ defmodule BrothTest.User.AdminUpdateTest do
     test "works for ben awad", t do
       ref =
         WsClient.send_call(t.client_ws, "user:admin_update", %{
-          "username" => t.staff_user.username,
+          "id" => t.staff_user.id,
           "user" => %{
             "staff" => true,
             "contributions" => 100
@@ -63,7 +63,7 @@ defmodule BrothTest.User.AdminUpdateTest do
 
       ref =
         WsClient.send_call(staff_ws, "user:admin_update", %{
-          "username" => should_become_staff.username,
+          "id" => should_become_staff.id,
           "user" => %{
             "staff" => true,
             "contributions" => 100
@@ -81,7 +81,7 @@ defmodule BrothTest.User.AdminUpdateTest do
 
     test "can update single field", t do
       WsClient.do_call(t.client_ws, "user:admin_update", %{
-        "username" => t.staff_user.username,
+        "id" => t.staff_user.id,
         "user" => %{
           "staff" => true,
           "contributions" => 100
@@ -90,7 +90,7 @@ defmodule BrothTest.User.AdminUpdateTest do
 
       ref =
         WsClient.send_call(t.client_ws, "user:admin_update", %{
-          "username" => t.staff_user.username,
+          "id" => t.staff_user.id,
           "user" => %{
             "staff" => false
           }


### PR DESCRIPTION
- make `user:admin_update` require `id` instead of `username`
- removes the staff/contrib modification options from `/admin` as it already exists on user profile
 
@benawad asked for this