### PR TITLE
fix(kibbeh): updated text parser regex

### DIFF
--- a/kibbeh/src/modules/display/TextParser.tsx
+++ b/kibbeh/src/modules/display/TextParser.tsx
@@ -9,9 +9,9 @@ interface TextParserProps {
 
 export const TextParser: React.FC<TextParserProps> = ({ children }) => {
   return (<>
-    {children.split(/(?=[ ,\n])|(?<=[ ,\n])/g).map((text, i) => {
+    {children.split(/(?=[ ,\n])/g).map((text, i) => {
       if (new RegExp(linkRegex).test(text)) return <a key={i} className={"text-accent text-center hover:underline inline font-bold"} href={text}>{text}</a>;
-      if (emojiRegex().test(text)) return <ParseTextToTwemoji key={i} text={text}/>;
+      if (emojiRegex().test(text)) return <ParseTextToTwemoji key={i} text={text} />;
       return text;
     })}
   </>


### PR DESCRIPTION
Safari doesn't support lookbehind.

Fix #2725