### PR TITLE
kousa: fixes and improvements 

### DIFF
--- a/kousa/lib/beef/access/rooms.ex
+++ b/kousa/lib/beef/access/rooms.ex
@@ -132,6 +132,7 @@ defmodule Beef.Access.Rooms do
 
   def search_name(start_of_name) do
     search_str = start_of_name <> "%"
+    search_str = String.replace(search_str, ~r/([_])/, ~s(\\\_))
 
     Query.start()
     |> where([r], ilike(r.name, ^search_str) and r.isPrivate == false)

--- a/kousa/lib/beef/access/users.ex
+++ b/kousa/lib/beef/access/users.ex
@@ -37,6 +37,22 @@ defmodule Beef.Access.Users do
     |> Repo.all()
   end
 
+  def search_user(<<first_letter>> <> rest) when first_letter == ?@ do
+    search_user(rest)
+  end
+
+  def search_user(username_or_display_name) do
+    search_str = username_or_display_name <> "%"
+    search_str = String.replace(search_str, ~r/([_])/, ~s(\\\_))
+
+    Query.start()
+    # here
+    |> where([u], ilike(u.username, ^search_str) or ilike(u.displayName, ^search_str))
+    |> order_by([u], desc: u.numFollowers)
+    |> limit([], 15)
+    |> Repo.all()
+  end
+
   @spec get_by_id_with_follow_info(any, any) :: any
   def get_by_id_with_follow_info(me_id, them_id) do
     Query.start()

--- a/kousa/lib/broth/message/misc/search.ex
+++ b/kousa/lib/broth/message/misc/search.ex
@@ -47,7 +47,7 @@ defmodule Broth.Message.Misc.Search do
     case apply_action(changeset, :validate) do
       {:ok, %{query: query}} ->
         rooms = Rooms.search_name(query)
-        users = Users.search_username(query)
+        users = Users.search_user(query)
         items = Enum.concat(rooms, users)
 
         {:reply, %Reply{items: items, rooms: rooms, users: users, nextCursor: nil}, state}

--- a/kousa/lib/kousa/room.ex
+++ b/kousa/lib/kousa/room.ex
@@ -267,7 +267,8 @@ defmodule Kousa.Room do
   defp set_listener(room_id, user_id, setter_id) do
     # TODO: refactor this to be simpler.  The list of
     # creators and mods should be in the preloads of the room.
-    with {auth, _} <- Rooms.get_room_status(setter_id), {role, _} <- Rooms.get_room_status(user_id) do
+    with {auth, _} <- Rooms.get_room_status(setter_id),
+         {role, _} <- Rooms.get_room_status(user_id) do
       if auth == :creator or (auth == :mod and role not in [:creator, :mod]) do
         internal_set_listener(user_id, room_id)
       end
@@ -327,22 +328,24 @@ defmodule Kousa.Room do
   end
 
   # only you can raise your own hand
-  defp set_raised_hand(room_id, user_id, _user_id) do
-    if Onion.RoomSession.get(room_id, :auto_speaker) do
-      internal_set_speaker(user_id, room_id)
-    else
-      case RoomPermissions.ask_to_speak(user_id, room_id) do
-        {:ok, %{isSpeaker: true}} ->
-          internal_set_speaker(user_id, room_id)
+  defp set_raised_hand(room_id, user_id, setter_id) do
+    if user_id == setter_id do
+      if Onion.RoomSession.get(room_id, :auto_speaker) do
+        internal_set_speaker(user_id, room_id)
+      else
+        case RoomPermissions.ask_to_speak(user_id, room_id) do
+          {:ok, %{isSpeaker: true}} ->
+            internal_set_speaker(user_id, room_id)
 
-        _ ->
-          Onion.RoomSession.broadcast_ws(
-            room_id,
-            %{
-              op: "hand_raised",
-              d: %{userId: user_id, roomId: room_id}
-            }
-          )
+          _ ->
+            Onion.RoomSession.broadcast_ws(
+              room_id,
+              %{
+                op: "hand_raised",
+                d: %{userId: user_id, roomId: room_id}
+              }
+            )
+        end
       end
     end
   end

--- a/kousa/lib/kousa/room.ex
+++ b/kousa/lib/kousa/room.ex
@@ -146,8 +146,7 @@ defmodule Kousa.Room do
   # owner
 
   def set_owner(room_id, user_id, setter_id) do
-    with {:creator, _} <- Rooms.get_room_status(setter_id),
-         {1, _} <- Rooms.replace_room_owner(setter_id, user_id) do
+    with {:creator, _} <- Rooms.get_room_status(setter_id), {1, _} <- Rooms.replace_room_owner(setter_id, user_id) do
       Onion.RoomSession.set_room_creator_id(room_id, user_id)
       internal_set_speaker(setter_id, room_id)
 


### PR DESCRIPTION
- fixes bot mute exploit that allows bots to mute any speaker at will *(#2774)*
- fixes issue where you can't search ppl with `_` in their name *(#2755)*
- allows search to also show results based on user's display names