### PR TITLE
fix(kibbeh): fix header clip on iOS with keyboard open

### DIFF
--- a/kibbeh/src/modules/room/mobile/RoomOverlay.tsx
+++ b/kibbeh/src/modules/room/mobile/RoomOverlay.tsx
@@ -14,6 +14,7 @@ import {
 import { RoomChatController } from "../RoomChatController";
 import useWindowSize from "../../../shared-hooks/useWindowSize";
 import { BoxedIcon } from "../../../ui/BoxedIcon";
+import useViewportSize from "../../../shared-hooks/useViewportSize";
 
 interface RoomOverlayProps {
   mute?: {
@@ -40,8 +41,9 @@ const RoomOverlay: React.FC<RoomOverlayProps> = ({
   setListener,
   canSpeak,
 }) => {
-  const { height: vHeight } = useWindowSize();
-  const height = vHeight - 30 - 100;
+  const { height: windowHeight } = useWindowSize();
+  const { height: viewportHeight } = useViewportSize();
+  const height = windowHeight - 30 - 100;
   const [{ y }, set] = useSpring(() => ({ y: height }));
 
   const open = () => {
@@ -94,7 +96,7 @@ const RoomOverlay: React.FC<RoomOverlayProps> = ({
         className="bg-primary-800 w-full rounded-t-20 z-10 absolute bottom-0 flex flex-col"
         style={{
           bottom: `calc(-100% + ${height + 100 + 30}px)`,
-          height: vHeight - 30,
+          height: viewportHeight - 30,
           y,
           zIndex: 11,
           touchAction: "none",

--- a/kibbeh/src/shared-hooks/useViewportSize.ts
+++ b/kibbeh/src/shared-hooks/useViewportSize.ts
@@ -8,34 +8,34 @@ interface WindowSize {
 
 const useWindowSize = () => {
   const [windowSize, setWindowSize] = useState<WindowSize>({
-    width: visualViewport.width ?? window.innerWidth,
-    height: visualViewport.height ?? window.innerHeight,
+    width: window.visualViewport?.width ?? window.innerWidth,
+    height: window.visualViewport?.height ?? window.innerHeight,
   });
 
   useEffect(() => {
     const handleResize = () => {
       setWindowSize({
-        width: visualViewport.width ?? window.innerWidth,
-        height: visualViewport.height ?? window.innerHeight,
+        width: window.visualViewport?.width ?? window.innerWidth,
+        height: window.visualViewport?.height ?? window.innerHeight,
       });
     };
 
     const debounced = debounce(handleResize, 1000);
 
-    if(!visualViewport) {
+    if(!window.visualViewport) {
       window.addEventListener("resize", debounced);
     } else {
-      visualViewport.addEventListener("resize", debounced);
+      window.visualViewport.addEventListener("resize", debounced);
     }
 
     handleResize();
 
     return () => {
       debounced.cancel(); // Prevents killing func while handleResize is running
-      if(!visualViewport) {
+      if(!window.visualViewport) {
         window.removeEventListener("resize", debounced);
       } else {
-        visualViewport.removeEventListener("resize", debounced);
+        window.visualViewport.removeEventListener("resize", debounced);
       }
     };
   }, []);

--- a/kibbeh/src/shared-hooks/useViewportSize.ts
+++ b/kibbeh/src/shared-hooks/useViewportSize.ts
@@ -1,0 +1,46 @@
+import { debounce } from "lodash";
+import { useEffect, useState } from "react";
+
+interface WindowSize {
+  width: number;
+  height: number;
+}
+
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: visualViewport.width ?? window.innerWidth,
+    height: visualViewport.height ?? window.innerHeight,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize({
+        width: visualViewport.width ?? window.innerWidth,
+        height: visualViewport.height ?? window.innerHeight,
+      });
+    };
+
+    const debounced = debounce(handleResize, 1000);
+
+    if(!visualViewport) {
+      window.addEventListener("resize", debounced);
+    } else {
+      visualViewport.addEventListener("resize", debounced);
+    }
+
+    handleResize();
+
+    return () => {
+      debounced.cancel(); // Prevents killing func while handleResize is running
+      if(!visualViewport) {
+        window.removeEventListener("resize", debounced);
+      } else {
+        visualViewport.removeEventListener("resize", debounced);
+      }
+    };
+  }, []);
+
+  return windowSize;
+};
+
+export default useWindowSize;


### PR DESCRIPTION
fix #2496
this also creates a new hook similar to `useWindowSize()` that uses the [VisualViewport API](https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport) instead.
That hook will use the window size if the VisualViewport API is not supported (Firefox)